### PR TITLE
Ignore query mocking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 ## Changelog
 
 ### Next
+- Ignoring query path for mocks
+- Missing mocks no longer break tests (removed fatalError)
+- Support for delayed responses
+- Support for redirect responses
+- Support for ignoring URLs for mocking
+- Support for ZIP content responses
+- Updated for Swift 4
+- Improved SwiftLint implementation
 
 ### 1.0 (2017-08-11)
 

--- a/Mocker/MockerTests/MockerTests.swift
+++ b/Mocker/MockerTests/MockerTests.swift
@@ -62,6 +62,30 @@ final class MockerTests: XCTestCase {
         
         waitForExpectations(timeout: 10.0, handler: nil)
     }
+
+    /// It should correctly ignore queries if set.
+    func testIgnoreQueryMocking() {
+        let expectation = self.expectation(description: "Data request should succeed")
+        let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
+
+        Mock(url: originalURL, ignoreQuery: true, dataType: .imagePNG, statusCode: 200, data: [
+            .get: MockedData.botAvatarImageFileUrl.data
+        ]).register()
+
+        /// Make it different compared to the mocked URL.
+        let customURL = URL(string: originalURL.absoluteString + "&" + UUID().uuidString)!
+
+        URLSession.shared.dataTask(with: customURL) { (data, _, error) in
+            XCTAssert(error == nil)
+            let image: UIImage = UIImage(data: data!)!
+            let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
+
+            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            expectation.fulfill()
+        }.resume()
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
     
     /// It should return the mocked JSON.
     func testJSONRequest() {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
 }.resume()
 ```
 
+##### Ignoring the query
+Some URLs like authentication URLs contain timestamps or UUIDs in the query. To mock these you can ignore the Query for a certain URL:
+
+``` swift
+/// Would transform to "https://www.wetransfer.com/api/authentication?oauth_timestamp=151817037" for example.
+let originalURL = URL(string: "https://www.wetransfer.com/api/authentication")!
+    
+let mock = Mock(url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200, data: [
+    .get : MockedData.exampleJSON.data // Data containing the JSON response
+])
+mock.register()
+
+URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
+    guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+        return
+    }
+    
+    // jsonDictionary contains your JSON sample file data
+    // ..
+    
+}.resume()
+```
+
 ##### File extensions
 ```swift
 let imageURL = URL(string: "https://www.wetransfer.com/sample-image.png")!

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
 Some URLs like authentication URLs contain timestamps or UUIDs in the query. To mock these you can ignore the Query for a certain URL:
 
 ``` swift
-/// Would transform to "https://www.wetransfer.com/api/authentication?oauth_timestamp=151817037" for example.
-let originalURL = URL(string: "https://www.wetransfer.com/api/authentication")!
+/// Would transform to "https://www.example.com/api/authentication?oauth_timestamp=151817037" for example.
+let originalURL = URL(string: "https://www.example.com/api/authentication")!
     
 let mock = Mock(url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200, data: [
     .get : MockedData.exampleJSON.data // Data containing the JSON response


### PR DESCRIPTION
Added the possibility to ignore queries when mocking. This is to support mocking cases with for example an authentication URL which adds parameters like `oauth_timestamp=151817037`. By ignoring the query parameters for mocking we prevent us from writing static timestamps for tests.