### PR TITLE
Matching specific Mocks over generic Mocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 source "https://rubygems.org"
 
 # Needed for Fastlane & Danger
-gem 'fastlane', '~>2.86.2'
+gem 'fastlane'
 gem 'danger'
-gem 'danger-swiftlint', '~>0.13.1'
+gem 'danger-swiftlint', '0.17.4'
 gem 'danger-xcov'
 gem 'danger-xcode_summary'
 gem 'xcpretty'

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -65,6 +65,11 @@ public struct Mocker {
     /// - Parameter request: The request to search for a mock.
     /// - Returns: A mock if found, `nil` if there's no mocked data registered for the given request.
     static func mock(for request: URLRequest) -> Mock? {
+        /// First check for specific URLs
+        if let specificMock = shared.mocks.first(where: { $0 == request && $0.fileExtensions == nil }) {
+            return specificMock
+        }
+        /// Second, check for generic file extension Mocks
         return shared.mocks.first(where: { $0 == request })
     }
 }


### PR DESCRIPTION
File Extensions `Mock`s are ignored if a specific URL `Mock` exists.