### PR TITLE
Added a completion callback for when a mock is used

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Next
+- A new completion callback can be set on `Mock` to use for expectation fulfilling once a `Mock` is used.
+
 ### 1.3.0
 - Updated to Swift 4.2
 

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -253,7 +253,7 @@ final class MockerTests: XCTestCase {
         XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)) == false)
     }
     
-    // It should be possible to compose a url relative to a base and still have it match the full url
+    /// It should be possible to compose a url relative to a base and still have it match the full url
     func testComposedURLMatch() {
         let composedURL = URL(fileURLWithPath: "resource", relativeTo: URL(string: "https://host.com/api/"))
         let simpleURL = URL(string: "https://host.com/api/resource")
@@ -261,5 +261,19 @@ final class MockerTests: XCTestCase {
         let urlRequest = URLRequest(url: simpleURL!)
         XCTAssertEqual(composedURL.absoluteString, simpleURL!.absoluteString)
         XCTAssert(mock == urlRequest)
+    }
+
+    /// It should call the completion callback when a `Mock` is used.
+    func testCompletionCallback() {
+        let expectation = self.expectation(description: "Data request should succeed")
+        var mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+        mock.completion = {
+            expectation.fulfill()
+        }
+        mock.register()
+
+        URLSession.shared.dataTask(with: mock.url).resume()
+
+        waitForExpectations(timeout: 2.0, handler: nil)
     }
 }

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -78,6 +78,9 @@ public struct Mock: Equatable {
     
     /// Add a delay to a certain mock, which makes the response returned later.
     public var delay: DispatchTimeInterval?
+
+    /// The callback which will be executed everytime this `Mock` was used. Can be used within unit tests for validating that a request has been executed.
+    public var completion: (() -> Void)?
     
     private init(url: URL? = nil, ignoreQuery: Bool = false, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:], fileExtensions: [String]? = nil) {
         self.url = url ?? URL(string: "https://mocked.wetransfer.com/\(dataType.rawValue)/\(statusCode)/")!

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -36,6 +36,8 @@ public final class MockingURLProtocol: URLProtocol {
                 self.client?.urlProtocol(self, didLoad: data)
                 self.client?.urlProtocolDidFinishLoading(self)
             }
+
+            mock.completion?()
         }
     }
     


### PR DESCRIPTION
The `completion` property on a `Mock` can be used for verifying that a request has been executed. This makes testing a lot easier.