### PR TITLE
Dispatching optimised and is only done when required

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### Next
 - A new completion callback can be set on `Mock` to use for expectation fulfilling once a `Mock` is used.
 - Updated to Swift 5.0
+- Only dispatch to the background queue if needed
 
 ### 1.3.0
 - Updated to Swift 4.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Updated to Swift 5.0
 - Only dispatch to the background queue if needed
 - Correctly handle cancellation of delayed responses
+- Adding and reading mocks is now thread safe by using a Dispatch Semaphore
 
 ### 1.3.0
 - Updated to Swift 4.2

--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		503446141F3DB4660039D5E4 /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		503446151F3DB4660039D5E4 /* Mocker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocker.swift; sourceTree = "<group>"; };
 		503446161F3DB4660039D5E4 /* MockingURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingURLProtocol.swift; sourceTree = "<group>"; };
+		506277CC235F2777000A4316 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
 		50D4605B20653EAF00A85D93 /* MockedData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockedData.swift; sourceTree = "<group>"; };
 		50D4605C20653EAF00A85D93 /* MockerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockerTests.swift; sourceTree = "<group>"; };
 		50D4606320653EAF00A85D93 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -63,6 +64,7 @@
 		501E268A1F3DAE370048F39E = {
 			isa = PBXGroup;
 			children = (
+				506277CC235F2777000A4316 /* Changelog.md */,
 				501E26951F3DAE370048F39E /* Products */,
 				50D4606A20653F1F00A85D93 /* Mocker */,
 				50D4605A20653EAF00A85D93 /* MockerTests */,

--- a/Mocker.xcodeproj/xcshareddata/xcschemes/Mocker.xcscheme
+++ b/Mocker.xcodeproj/xcshareddata/xcschemes/Mocker.xcscheme
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "501E26931F3DAE370048F39E"
+            BuildableName = "Mocker.framework"
+            BlueprintName = "Mocker"
+            ReferencedContainer = "container:Mocker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -41,17 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "501E26931F3DAE370048F39E"
-            BuildableName = "Mocker.framework"
-            BlueprintName = "Mocker"
-            ReferencedContainer = "container:Mocker.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,8 +70,6 @@
             ReferencedContainer = "container:Mocker.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -28,7 +28,9 @@ public struct Mocker {
     
     /// URLs to ignore for mocking.
     private(set) var ignoredURLs: [URL] = []
-    
+
+    private let mutex = DispatchSemaphore(value: 1)
+
     private init() {
         // Whenever someone is requesting the Mocker, we want the URL protocol to be activated.
         URLProtocol.registerClass(MockingURLProtocol.self)
@@ -38,16 +40,20 @@ public struct Mocker {
     ///
     /// - Parameter mock: The Mock to be registered for future requests.
     public static func register(_ mock: Mock) {
-        /// Delete the Mock if it was already registered.
-        shared.mocks.removeAll(where: { $0 == mock })
-        shared.mocks.append(mock)
+        shared.mutex.lock {
+            /// Delete the Mock if it was already registered.
+            shared.mocks.removeAll(where: { $0 == mock })
+            shared.mocks.append(mock)
+        }
     }
     
     /// Register an URL to ignore for mocking. This will let the URL work as if the Mocker doesn't exist.
     ///
     /// - Parameter url: The URL to mock.
     public static func ignore(_ url: URL) {
-        shared.ignoredURLs.append(url)
+        return shared.mutex.lock {
+            shared.ignoredURLs.append(url)
+        }
     }
     
     /// Checks if the passed URL should be handled by the Mocker. If the URL is registered to be ignored, it will not handle the URL.
@@ -55,12 +61,16 @@ public struct Mocker {
     /// - Parameter url: The URL to check for.
     /// - Returns: `true` if it should be mocked, `false` if the URL is registered as ignored.
     public static func shouldHandle(_ url: URL) -> Bool {
-        return !shared.ignoredURLs.contains(url)
+        return shared.mutex.lock {
+            return !shared.ignoredURLs.contains(url)
+        }
     }
 
     /// Removes all registered mocks. Use this method in your tearDown function to make sure a Mock is not used in any other test.
     public static func removeAll() {
-        shared.mocks.removeAll()
+        shared.mutex.lock {
+            shared.mocks.removeAll()
+        }
     }
     
     /// Retrieve a Mock for the given request. Matches on `request.url` and `request.httpMethod`.
@@ -68,11 +78,21 @@ public struct Mocker {
     /// - Parameter request: The request to search for a mock.
     /// - Returns: A mock if found, `nil` if there's no mocked data registered for the given request.
     static func mock(for request: URLRequest) -> Mock? {
-        /// First check for specific URLs
-        if let specificMock = shared.mocks.first(where: { $0 == request && $0.fileExtensions == nil }) {
-            return specificMock
+        return shared.mutex.lock {
+            /// First check for specific URLs
+            if let specificMock = shared.mocks.first(where: { $0 == request && $0.fileExtensions == nil }) {
+                return specificMock
+            }
+            /// Second, check for generic file extension Mocks
+            return shared.mocks.first(where: { $0 == request })
         }
-        /// Second, check for generic file extension Mocks
-        return shared.mocks.first(where: { $0 == request })
+    }
+}
+
+private extension DispatchSemaphore {
+    func lock<T>(execute task: () throws -> T) rethrows -> T {
+        wait()
+        defer { signal() }
+        return try task()
     }
 }

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -40,7 +40,7 @@ public final class MockingURLProtocol: URLProtocol {
             self.finishRequest(for: mock, data: data, response: response)
         })
 
-        DispatchQueue.global(qos: DispatchQoS.QoSClass.background).asyncAfter(deadline: .now() + delay), execute: responseWorkItem!)
+        DispatchQueue.global(qos: DispatchQoS.QoSClass.background).asyncAfter(deadline: .now() + delay, execute: responseWorkItem!)
     }
 
     private func finishRequest(for mock: Mock, data: Data, response: HTTPURLResponse) {


### PR DESCRIPTION
We were always dispatching even though we would not have a delay set to a mock. This could be a small performance hit and, therefore, we change it to only dispatch if needed.

Also added thread safety adding and reading of mocks using a Dispatch Semaphore