### PR TITLE
Improve the way we match registered Mocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.2
+osx_image: xcode11.2
 gemfile: Gemfile
 bundler_args: "--without documentation --path bundle" # Don't download documentation for gems.
 cache:

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Correctly handle cancellation of delayed responses
 - Adding and reading mocks is now thread safe by using a Dispatch Semaphore
 - Add support for using Swift Package Manager
+- Improved checking for Mocks using `URLRequest`.
 
 ### 1.3.0
 - Updated to Swift 4.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Next
+
+### 2.0.0
 - A new completion callback can be set on `Mock` to use for expectation fulfilling once a `Mock` is completed.
 - A new onRequest callback can be set on `Mock` to use for expectation fulfilling once a `Mock` is requested.
 - Updated to Swift 5.0

--- a/Mocker.podspec
+++ b/Mocker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Mocker'
-  spec.version          = '1.3.0'
+  spec.version          = '2.0.0'
   spec.summary          = 'Mock data requests using a custom URLProtocol and run them offline.'
   spec.description      = 'Mocker is a library written in Swift which makes it possible to mock data requests using a custom URLProtocol and run them offline.'
 
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/WeTransfer/Mocker.git', :tag => spec.version.to_s }
   spec.social_media_url = 'https://twitter.com/WeTransfer'
 
-  spec.ios.deployment_target = '9.0'
+  spec.ios.deployment_target = '10.0'
   spec.source_files = 'Sources/**/*'
-  spec.swift_version = '4.2'
+  spec.swift_version = '5.1'
 end

--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 /* Begin PBXFileReference section */
 		501E26941F3DAE370048F39E /* Mocker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mocker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		501E269D1F3DAE370048F39E /* MockerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MockerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		501F8B2D237594AC008EF77E /* Mocker.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Mocker.podspec; sourceTree = "<group>"; };
 		503446141F3DB4660039D5E4 /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		503446151F3DB4660039D5E4 /* Mocker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mocker.swift; sourceTree = "<group>"; };
 		503446161F3DB4660039D5E4 /* MockingURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingURLProtocol.swift; sourceTree = "<group>"; };
@@ -65,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				506277CC235F2777000A4316 /* Changelog.md */,
+				501F8B2D237594AC008EF77E /* Mocker.podspec */,
 				501E26951F3DAE370048F39E /* Products */,
 				50D4606A20653F1F00A85D93 /* Mocker */,
 				50D4605A20653EAF00A85D93 /* MockerTests */,

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -30,7 +30,7 @@ public struct Mocker {
     private(set) var ignoredURLs: [URL] = []
 
     /// For Thread Safety access.
-    private let queue = DispatchQueue(label: "mocker.serial.queue")
+    private let queue = DispatchQueue(label: "mocker.mocks.access.queue", attributes: .concurrent)
 
     private init() {
         // Whenever someone is requesting the Mocker, we want the URL protocol to be activated.
@@ -41,7 +41,7 @@ public struct Mocker {
     ///
     /// - Parameter mock: The Mock to be registered for future requests.
     public static func register(_ mock: Mock) {
-        shared.queue.async {
+        shared.queue.async(flags: .barrier) {
             /// Delete the Mock if it was already registered.
             shared.mocks.removeAll(where: { $0 == mock })
             shared.mocks.append(mock)
@@ -52,7 +52,7 @@ public struct Mocker {
     ///
     /// - Parameter url: The URL to mock.
     public static func ignore(_ url: URL) {
-        shared.queue.async {
+        shared.queue.async(flags: .barrier) {
             shared.ignoredURLs.append(url)
         }
     }
@@ -69,7 +69,7 @@ public struct Mocker {
 
     /// Removes all registered mocks. Use this method in your tearDown function to make sure a Mock is not used in any other test.
     public static func removeAll() {
-        shared.queue.async {
+        shared.queue.async(flags: .barrier) {
             shared.mocks.removeAll()
         }
     }

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -69,7 +69,7 @@ public struct Mocker {
 
     /// Removes all registered mocks. Use this method in your tearDown function to make sure a Mock is not used in any other test.
     public static func removeAll() {
-        shared.queue.async(flags: .barrier) {
+        shared.queue.sync(flags: .barrier) {
             shared.mocks.removeAll()
         }
     }

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -21,7 +21,7 @@ public final class MockingURLProtocol: URLProtocol {
     override public func startLoading() {
         guard
             let mock = Mocker.mock(for: request),
-            let response = HTTPURLResponse(url: mock.url, statusCode: mock.statusCode, httpVersion: Mocker.httpVersion.rawValue, headerFields: mock.headers),
+            let response = HTTPURLResponse(url: mock.request.url!, statusCode: mock.statusCode, httpVersion: Mocker.httpVersion.rawValue, headerFields: mock.headers),
             let data = mock.data(for: request)
         else {
             // swiftlint:disable nslog_prohibited

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,7 @@ lane :test do |options|
     UI.error("Tests failed: #{ex}")
   end
 
-  trainer(output_directory: "build/reports/", fail_build: false)
+  trainer(path: "build/reports/", output_directory: "build/reports/", fail_build: false)
 
   validate_changes(project_name: options[:project_name])
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,8 @@ lane :test do |options|
       fail_build: false,
       code_coverage: true,
       formatter: "xcpretty-json-formatter",
-      result_bundle: true
+      result_bundle: true,
+      output_directory: "build/reports/"
     )
   rescue => ex
     UI.error("Tests failed: #{ex}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,8 @@ lane :test do |options|
       clean: true,
       fail_build: false,
       code_coverage: true,
-      formatter: "xcpretty-json-formatter"
+      formatter: "xcpretty-json-formatter",
+      result_bundle: true
     )
   rescue => ex
     UI.error("Tests failed: #{ex}")


### PR DESCRIPTION
Catches cases in which there isn't a specific URL register while a data type of POST is asked. This does not work and should be caught using an assertion failure to help debugging.