### PR TITLE
Fix important mismatch for getting the right mock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 ## Changelog
 
 ### Next
-- `MockingURLProtocol` Error is now localized
+- `MockingURLProtocol` Error now conforms to `CustomDebugStringConvertible` for better debugging logs.
+- Fixed a bug in which two Mocks would not be registered for the same URL if the HTTP method was different.
 
 ### 2.0.0
 - A new completion callback can be set on `Mock` to use for expectation fulfilling once a `Mock` is completed.

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -312,4 +312,16 @@ final class MockerTests: XCTestCase {
         Mocker.removeAll()
         XCTAssertTrue(Mocker.shared.mocks.isEmpty)
     }
+
+    /// It should correctly add two mocks for the same URL if the HTTP method is different.
+    func testDifferentHTTPMethodSameURL() {
+        let url = URL(string: "https://www.fakeurl.com/\(UUID().uuidString)")!
+        Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()]).register()
+        Mock(url: url, dataType: .json, statusCode: 200, data: [.put: Data()]).register()
+        var request = URLRequest(url: url)
+        request.httpMethod = Mock.HTTPMethod.get.rawValue
+        XCTAssertNotNil(Mocker.mock(for: request))
+        request.httpMethod = Mock.HTTPMethod.put.rawValue
+        XCTAssertNotNil(Mocker.mock(for: request))
+    }
 }

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -185,7 +185,7 @@ public struct Mock: Equatable {
     
     public static func == (lhs: Mock, rhs: Mock) -> Bool {
         let lhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }
-        let rhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }
+        let rhsHTTPMethods: [String] = rhs.data.keys.compactMap { $0.rawValue }
         return lhs.request.url!.absoluteString == rhs.request.url!.absoluteString && lhsHTTPMethods == rhsHTTPMethods
     }
 }

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -11,10 +11,14 @@ import Foundation
 /// The protocol which can be used to send Mocked data back. Use the `Mocker` to register `Mock` data
 public final class MockingURLProtocol: URLProtocol {
 
-    enum Error: Swift.Error, LocalizedError {
+    enum Error: Swift.Error, LocalizedError, CustomDebugStringConvertible {
         case missingMockedData(url: String)
 
         var errorDescription: String? {
+            return debugDescription
+        }
+
+        var debugDescription: String {
             switch self {
             case .missingMockedData(let url):
                 return "Missing mock for URL: \(url)"


### PR DESCRIPTION
Classic mistake, a small typo. Added a test to reproduce the issue so we don't do this again.