### PR TITLE
ignoring query example swap i/o url

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
 Some URLs like authentication URLs contain timestamps or UUIDs in the query. To mock these you can ignore the Query for a certain URL:
 
 ``` swift
-/// Would transform to "https://www.example.com/api/authentication?oauth_timestamp=151817037" for example.
-let originalURL = URL(string: "https://www.example.com/api/authentication")!
+/// Would transform to "https://www.example.com/api/authentication" for example.
+let originalURL = URL(string: "https://www.example.com/api/authentication?oauth_timestamp=151817037")!
     
 let mock = Mock(url: originalURL, ignoreQuery: true, dataType: .json, statusCode: 200, data: [
     .get : MockedData.exampleJSON.data // Data containing the JSON response


### PR DESCRIPTION
Hi,
I think there's an error in the README.
Thanks.