### PR TITLE
Add Dynamic Mock support

### DIFF
--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 				503446131F3DB4660039D5E4 /* Sources */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		501E26951F3DAE370048F39E /* Products */ = {
 			isa = PBXGroup;

--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2FBE74052494492D00444193 /* DynamicMocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBE74042494492D00444193 /* DynamicMocksTests.swift */; };
 		501B8FC4247E89C600B885F4 /* XCTest+Mocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */; };
 		501E269E1F3DAE370048F39E /* Mocker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501E26941F3DAE370048F39E /* Mocker.framework */; };
 		503446171F3DB4660039D5E4 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503446141F3DB4660039D5E4 /* Mock.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2FBE74042494492D00444193 /* DynamicMocksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicMocksTests.swift; sourceTree = "<group>"; };
 		501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Mocker.swift"; sourceTree = "<group>"; };
 		501B8FC5247E8BDE00B885F4 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		501E26941F3DAE370048F39E /* Mocker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mocker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,6 +105,7 @@
 			children = (
 				50D4605B20653EAF00A85D93 /* MockedData.swift */,
 				50D4605C20653EAF00A85D93 /* MockerTests.swift */,
+				2FBE74042494492D00444193 /* DynamicMocksTests.swift */,
 				50D4607220653F4500A85D93 /* Resources */,
 				50D4606220653EAF00A85D93 /* Supporting Files */,
 			);
@@ -280,6 +283,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50D4607120653F2700A85D93 /* MockerTests.swift in Sources */,
+				2FBE74052494492D00444193 /* DynamicMocksTests.swift in Sources */,
 				50D4607020653F2500A85D93 /* MockedData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MockerTests/DynamicMocksTests.swift
+++ b/MockerTests/DynamicMocksTests.swift
@@ -1,0 +1,167 @@
+//
+//  DynamicMocksTests.swift
+//  MockerTests
+//
+//  Copyright © 2020 WeTransfer. All rights reserved.
+//
+
+@testable import Mocker
+import XCTest
+
+class DynamicMocksTests: XCTestCase {
+	override func setUpWithError() throws {
+		// make sure this is cleared before each test to avoid bleed-over between tests.
+		Mocker.onMockFor = nil
+	}
+
+	/// It should call `onMockFor` to change the mock used for a url for subsequent fetches during the same test
+	func testOnMockForConditionalReplacement() {
+		let service = FakeService()	// the service we are testing
+
+		// Create Mock data
+		let goodMockData = "{\"name\":\"Joe Jones\"}".data(using: .utf8)!
+		let goodTokenData = "{\"token\":\"good token\"}".data(using: .utf8)!
+
+		// Create our three Mocks:
+
+		let failingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+									  dataType: .json,
+									  statusCode: 401,
+									  data: [.get: Data()])
+		failingProfileMock.register()
+
+		let succeedingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+										 dataType: .json,
+										 statusCode: 200,
+										 data: [.get: goodMockData])
+		// succeedingMock.register() - Do NOT call now as will replace failingMock.
+		// Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
+
+		let refreshTokenMock = Mock(url: FakeService.FakeServiceURLs.refreshTokenURL,
+									dataType: .json,
+									statusCode: 200,
+									data: [.get: goodTokenData])
+		refreshTokenMock.register()
+
+		// Now set up our dynamic mock that will replace the failingProfileMock
+		// with the succeedingProfileMock IFF we have a valid token (if the refreshToken call is made
+		// and gets a valid token)
+
+		Mocker.onMockFor = { _ in
+			if FakeService.accessToken.token == "good token" {
+				return succeedingProfileMock
+			} else { return nil }
+		}
+
+		let expectFailure = expectation(description: "call url - should get error")
+
+		// Now make the profile call that we expect will fail, internally
+		// get a new token from the service, and then retry and finally return us valid profile data.
+		service.profile(for: "JJ") { profile, error in
+			XCTAssertNil(error)
+			XCTAssertNotNil(profile)
+			XCTAssertEqual(profile!.name, "Joe Jones")
+			expectFailure.fulfill()
+		}
+
+		wait(for: [expectFailure], timeout: 2.0)
+	}
+}
+
+// MARK: - Example Service Under Test -
+
+// This is a simplified version of the type of thing Dynamic Mocks will let you test.
+// This code would normally be somewhere in your app, significantly more complex, and
+// something you really need to write robust tests on.
+
+// This represents a service doing the fairly standard work of fetching a user profile, say.
+// As with most systems, an Access Token is required for access (imagine it's placed in an Authorization header).
+// If the token expires then a differnet API call must be made to fetch a refreshed token.
+
+class FakeService {
+	static var accessToken = Token(token: "bad token")	// this will actualy be in the keychain or similar
+
+	struct FakeServiceURLs {
+		static let profileURL = URL(string: "http://fakeservice.com/profile")!
+		static let refreshTokenURL = URL(string: "http://fakeservice.com/token/refresh")!
+	}
+
+	enum FakeServiceErrors: Error {
+		case urlError(URLError)
+		case badResponse
+		case tokenError	// unrecoverable token error
+		// ...
+		case unknownError
+	}
+
+	struct Profile: Decodable {
+		var name: String
+		// ...
+	}
+
+	struct Token: Decodable {
+		var token: String
+	}
+
+	func profile(for userID: String, retrying: Bool = false, _ completion: @escaping (Profile?, Error?) -> Void) {
+		// pretend the `accessToken` is used here by the service (put in Authorization header or something)
+		URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.profileURL)) { data, urlResponse, err in
+			guard err == nil else {
+				completion(nil, err!)
+				return
+			}
+			if let httpResponse = urlResponse as? HTTPURLResponse {
+				if httpResponse.statusCode == 200,
+					let profileData = data {
+					// return the successful Profile since we succeeded
+					do {
+						let profile = try JSONDecoder().decode(Profile.self, from: profileData)
+						completion(profile, nil)
+					} catch {
+						completion(nil, error)
+					}
+				} else if httpResponse.statusCode == 401, !retrying { // only try token fetch once (recursion limiter)
+					//
+					// we have to fetch a new token (say) via asynchronous service call
+					self.refreshToken(for: userID) { token, err in
+						if let token = token {
+							FakeService.accessToken = token		// not thread safe and totally insecure; just a mock
+							// recurse to try again; again, not how I'd normally do this, but adequate.
+							// Set retrying flag so don't recurse more than once, and pass caller's original completion handler
+							self.profile(for: userID, retrying: true, completion)
+						} else if let error = err {
+							print("failed to get a new token: \(error)")
+							completion(nil, FakeServiceErrors.tokenError)
+						} else {
+							// return unknown error
+							completion(nil, FakeServiceErrors.unknownError)
+						}
+					}
+				} else {
+					completion(nil, FakeServiceErrors.urlError(URLError(URLError.Code(rawValue: httpResponse.statusCode))))
+				}
+			} else {
+				completion(nil, FakeServiceErrors.badResponse)
+			}
+		}.resume()
+	}
+
+	func refreshToken(for userID: String, _ completion: @escaping (Token?, Error?) -> Void) {
+		URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.refreshTokenURL)) { data, urlResponse, _ in
+			// since we are mocking this and know it'll return 200, simplify this for the same of this example.
+			if let httpResponse = urlResponse as? HTTPURLResponse,
+				httpResponse.statusCode == 200,
+				let tokenData = data {
+				do {
+					let token = try JSONDecoder().decode(Token.self, from: tokenData)
+					completion(token, nil)
+				} catch {
+					completion(nil, error)
+				}
+			} else {
+				completion(nil, FakeServiceErrors.tokenError)
+			}
+
+		}.resume()
+	}
+}

--- a/MockerTests/DynamicMocksTests.swift
+++ b/MockerTests/DynamicMocksTests.swift
@@ -9,66 +9,69 @@
 import XCTest
 
 class DynamicMocksTests: XCTestCase {
-	override func setUpWithError() throws {
-		// make sure this is cleared before each test to avoid bleed-over between tests.
-		Mocker.onMockFor = nil
-	}
+    override func setUpWithError() throws {
+        // make sure this is cleared before each test to avoid bleed-over between tests.
+        Mocker.onMockFor = nil
+    }
 
-	/// It should call `onMockFor` to change the mock used for a url for subsequent fetches during the same test
-	func testOnMockForConditionalReplacement() {
-		let service = FakeService()	// the service we are testing
+    /// It should call `onMockFor` to change the mock used for a url for subsequent fetches during the same test
+    func testOnMockForConditionalReplacement() {
+        let service = FakeService() // the service we are testing
 
-		// Create Mock data
-		let goodMockData = "{\"name\":\"Joe Jones\"}".data(using: .utf8)!
-		let goodTokenData = "{\"token\":\"good token\"}".data(using: .utf8)!
+        // Create Mock data
+        let goodMockData = "{\"name\":\"Joe Jones\"}".data(using: .utf8)!
+        let goodTokenData = "{\"token\":\"good token\"}".data(using: .utf8)!
 
-		// Create our three Mocks:
+        // Create our three Mocks:
 
-		let failingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
-									  dataType: .json,
-									  statusCode: 401,
-									  data: [.get: Data()])
-		failingProfileMock.register()
+        let failingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                      dataType: .json,
+                                      statusCode: 401,
+                                      data: [.get: Data()])
+        failingProfileMock.register()
 
-		let succeedingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
-										 dataType: .json,
-										 statusCode: 200,
-										 data: [.get: goodMockData])
-		// succeedingMock.register() - Do NOT call now as will replace failingMock.
-		// Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
+        let succeedingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                         dataType: .json,
+                                         statusCode: 200,
+                                         data: [.get: goodMockData])
+        // succeedingMock.register() - Do NOT call now as will replace failingMock.
+        // Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
 
-		let refreshTokenMock = Mock(url: FakeService.FakeServiceURLs.refreshTokenURL,
-									dataType: .json,
-									statusCode: 200,
-									data: [.get: goodTokenData])
-		refreshTokenMock.register()
+        let refreshTokenMock = Mock(url: FakeService.FakeServiceURLs.refreshTokenURL,
+                                    dataType: .json,
+                                    statusCode: 200,
+                                    data: [.get: goodTokenData])
+        refreshTokenMock.register()
 
-		// Now set up our dynamic mock that will replace the failingProfileMock
-		// with the succeedingProfileMock IFF we have a valid token (if the refreshToken call is made
-		// and gets a valid token)
+        // Now set up our dynamic mock that will replace the failingProfileMock
+        // with the succeedingProfileMock IFF we have a valid token (if the refreshToken call is made
+        // and gets a valid token)
 
-		Mocker.onMockFor = { _ in
-			if FakeService.accessToken.token == "good token" {
-				return succeedingProfileMock
-			} else { return nil }
-		}
+        Mocker.onMockFor = { _ in
+            if FakeService.accessToken.token == "good token" {
+                return succeedingProfileMock
+            } else { return nil }
+        }
 
-		let expectFailure = expectation(description: "call url - should get error")
+        let expectFailure = expectation(description: "call url - should get error")
 
-		// Now make the profile call that we expect will fail, internally
-		// get a new token from the service, and then retry and finally return us valid profile data.
-		service.profile(for: "JJ") { profile, error in
-			XCTAssertNil(error)
-			XCTAssertNotNil(profile)
-			XCTAssertEqual(profile!.name, "Joe Jones")
-			expectFailure.fulfill()
-		}
+        // Now make the profile call that we expect will fail, internally
+        // get a new token from the service, and then retry and finally return us valid profile data.
+        service.profile(for: "JJ") { profile, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(profile)
+            XCTAssertEqual(profile!.name, "Joe Jones")
+            expectFailure.fulfill()
+        }
 
-		wait(for: [expectFailure], timeout: 2.0)
-	}
+        wait(for: [expectFailure], timeout: 2.0)
+    }
 }
 
 // MARK: - Example Service Under Test -
+
+// This code is NOT in a test file in a real project and so
+// CANNOT have any XCTestXXX or Expectations or anything in it.
 
 // This is a simplified version of the type of thing Dynamic Mocks will let you test.
 // This code would normally be somewhere in your app, significantly more complex, and
@@ -79,89 +82,90 @@ class DynamicMocksTests: XCTestCase {
 // If the token expires then a differnet API call must be made to fetch a refreshed token.
 
 class FakeService {
-	static var accessToken = Token(token: "bad token")	// this will actualy be in the keychain or similar
+    static var accessToken = Token(token: "bad token")  // this will actualy be in the keychain or similar
 
-	struct FakeServiceURLs {
-		static let profileURL = URL(string: "http://fakeservice.com/profile")!
-		static let refreshTokenURL = URL(string: "http://fakeservice.com/token/refresh")!
-	}
+    struct FakeServiceURLs {
+        static let profileURL = URL(string: "http://fakeservice.com/profile")!
+        static let refreshTokenURL = URL(string: "http://fakeservice.com/token/refresh")!
+    }
 
-	enum FakeServiceErrors: Error {
-		case urlError(URLError)
-		case badResponse
-		case tokenError	// unrecoverable token error
-		// ...
-		case unknownError
-	}
+    enum FakeServiceErrors: Error {
+        case urlError(URLError)
+        case badResponse
+        case tokenError // unrecoverable token error
+        // ...
+        case unknownError
+    }
 
-	struct Profile: Decodable {
-		var name: String
-		// ...
-	}
+    struct Profile: Decodable {
+        var name: String
+        // ...
+    }
 
-	struct Token: Decodable {
-		var token: String
-	}
+    struct Token: Decodable {
+        var token: String
+    }
 
-	func profile(for userID: String, retrying: Bool = false, _ completion: @escaping (Profile?, Error?) -> Void) {
-		// pretend the `accessToken` is used here by the service (put in Authorization header or something)
-		URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.profileURL)) { data, urlResponse, err in
-			guard err == nil else {
-				completion(nil, err!)
-				return
-			}
-			if let httpResponse = urlResponse as? HTTPURLResponse {
-				if httpResponse.statusCode == 200,
-					let profileData = data {
-					// return the successful Profile since we succeeded
-					do {
-						let profile = try JSONDecoder().decode(Profile.self, from: profileData)
-						completion(profile, nil)
-					} catch {
-						completion(nil, error)
-					}
-				} else if httpResponse.statusCode == 401, !retrying { // only try token fetch once (recursion limiter)
-					//
-					// we have to fetch a new token (say) via asynchronous service call
-					self.refreshToken(for: userID) { token, err in
-						if let token = token {
-							FakeService.accessToken = token		// not thread safe and totally insecure; just a mock
-							// recurse to try again; again, not how I'd normally do this, but adequate.
-							// Set retrying flag so don't recurse more than once, and pass caller's original completion handler
-							self.profile(for: userID, retrying: true, completion)
-						} else if let error = err {
-							print("failed to get a new token: \(error)")
-							completion(nil, FakeServiceErrors.tokenError)
-						} else {
-							// return unknown error
-							completion(nil, FakeServiceErrors.unknownError)
-						}
-					}
-				} else {
-					completion(nil, FakeServiceErrors.urlError(URLError(URLError.Code(rawValue: httpResponse.statusCode))))
-				}
-			} else {
-				completion(nil, FakeServiceErrors.badResponse)
-			}
-		}.resume()
-	}
+    func profile(for userID: String, retrying: Bool = false, _ completion: @escaping (Profile?, Error?) -> Void) {
+        // pretend the `accessToken` is used here by the service (put in Authorization header or something)
+        URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.profileURL)) { data, urlResponse, err in
+            guard err == nil else {
+                completion(nil, err!)
+                return
+            }
+            if let httpResponse = urlResponse as? HTTPURLResponse {
+                if httpResponse.statusCode == 200,
+                    let profileData = data {
+                    // return the successful Profile since we succeeded
+                    do {
+                        let profile = try JSONDecoder().decode(Profile.self, from: profileData)
+                        completion(profile, nil)
+                    } catch {
+                        completion(nil, error)
+                    }
+                } else if httpResponse.statusCode == 401, !retrying { // only try token fetch once (recursion limiter)
+                    //
+                    // we have to fetch a new token (say) via asynchronous service call
+                    self.refreshToken(for: userID) { token, err in
+                        if let token = token {
+                            FakeService.accessToken = token     // not thread safe and totally insecure; just a mock
+                            // recurse to try again; again, not how I'd normally do this, but adequate.
+                            // Set retrying flag so don't recurse more than once, and pass caller's original completion handler
+                            self.profile(for: userID, retrying: true, completion)
+                        } else if let error = err {
+                            print("failed to get a new token: \(error)")
+                            completion(nil, FakeServiceErrors.tokenError)
+                        } else {
+                            // return unknown error
+                            completion(nil, FakeServiceErrors.unknownError)
+                        }
+                    }
+                } else {
+                    completion(nil, FakeServiceErrors.urlError(URLError(URLError.Code(rawValue: httpResponse.statusCode))))
+                }
+            } else {
+                completion(nil, FakeServiceErrors.badResponse)
+            }
+        }.resume()
+    }
 
-	func refreshToken(for userID: String, _ completion: @escaping (Token?, Error?) -> Void) {
-		URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.refreshTokenURL)) { data, urlResponse, _ in
-			// since we are mocking this and know it'll return 200, simplify this for the same of this example.
-			if let httpResponse = urlResponse as? HTTPURLResponse,
-				httpResponse.statusCode == 200,
-				let tokenData = data {
-				do {
-					let token = try JSONDecoder().decode(Token.self, from: tokenData)
-					completion(token, nil)
-				} catch {
-					completion(nil, error)
-				}
-			} else {
-				completion(nil, FakeServiceErrors.tokenError)
-			}
+    func refreshToken(for userID: String, _ completion: @escaping (Token?, Error?) -> Void) {
+        URLSession.shared.dataTask(with: URLRequest(url: FakeServiceURLs.refreshTokenURL)) { data, urlResponse, _ in
+            // since we are mocking this and know it'll return 200, simplify this for the same of this example.
+            if let httpResponse = urlResponse as? HTTPURLResponse,
+                httpResponse.statusCode == 200,
+                let tokenData = data {
+                do {
+                    let token = try JSONDecoder().decode(Token.self, from: tokenData)
+                    completion(token, nil)
+                } catch {
+                    completion(nil, error)
+                }
+            } else {
+                completion(nil, FakeServiceErrors.tokenError)
+            }
 
-		}.resume()
-	}
+        }.resume()
+    }
 }
+

--- a/MockerTests/DynamicMocksTests.swift
+++ b/MockerTests/DynamicMocksTests.swift
@@ -66,6 +66,130 @@ class DynamicMocksTests: XCTestCase {
 
         wait(for: [expectFailure], timeout: 2.0)
     }
+
+    func FAILS_testOnMockForConditionalReplacementAvdLeeSuggestion1() {
+        let service = FakeService() // the service we are testing
+
+        // Create Mock data
+        let goodMockData = "{\"name\":\"Joe Jones\"}".data(using: .utf8)!
+        let goodTokenData = "{\"token\":\"good token\"}".data(using: .utf8)!
+
+        // Create our three Mocks:
+
+        let succeedingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                         dataType: .json,
+                                         statusCode: 200,
+                                         data: [.get: goodMockData])
+        // succeedingMock.register() - Do NOT call now as will get replaced by failingMock.
+        // Instead, try registering it in the `onRequest` handler for failingProfileMock
+        // if the token has been updated
+
+        var failingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                      dataType: .json,
+                                      statusCode: 401,
+                                      data: [.get: Data()])
+
+        failingProfileMock.onRequest = { _, _ in
+            // this won't help because it's too late.
+            if FakeService.accessToken.token == "good token" {
+                succeedingProfileMock.register()
+            }
+        }
+        failingProfileMock.register()
+
+        let refreshTokenMock = Mock(url: FakeService.FakeServiceURLs.refreshTokenURL,
+                                    dataType: .json,
+                                    statusCode: 200,
+                                    data: [.get: goodTokenData])
+        refreshTokenMock.register()
+
+        // Now set up our dynamic mock that will replace the failingProfileMock
+        // with the succeedingProfileMock IFF we have a valid token (if the refreshToken call is made
+        // and gets a valid token)
+
+        //        Mocker.onMockFor = { _ in
+        //            if FakeService.accessToken.token == "good token" {
+        //                return succeedingProfileMock
+        //            } else { return nil }
+        //        }
+
+        let expectFailure = expectation(description: "call url - should get error")
+
+        // Now make the profile call that we expect will fail, internally
+        // get a new token from the service, and then retry and finally return us valid profile data.
+        service.profile(for: "JJ") { profile, error in
+            XCTAssertNil(error, "error is not nil!")
+            XCTAssertNotNil(profile, "profile is nil")
+            XCTAssertEqual(profile?.name, "Joe Jones", "profile name doesn't match")
+            expectFailure.fulfill()
+        }
+
+        wait(for: [expectFailure], timeout: 2.0)
+    }
+
+    func FAILS_testOnMockForConditionalReplacementAvdLeeSuggestion2() {
+        let service = FakeService() // the service we are testing
+
+        // Create Mock data
+        let goodMockData = "{\"name\":\"Joe Jones\"}".data(using: .utf8)!
+        let goodTokenData = "{\"token\":\"good token\"}".data(using: .utf8)!
+
+        // Create our three Mocks:
+
+        let succeedingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                         dataType: .json,
+                                         statusCode: 200,
+                                         data: [.get: goodMockData])
+        // succeedingMock.register() - Do NOT call now as will get replaced by failingMock.
+        // Instead, try registering it in the `onRequest` handler for failingProfileMock
+        // if the token has been updated
+
+        let failingProfileMock = Mock(url: FakeService.FakeServiceURLs.profileURL,
+                                      dataType: .json,
+                                      statusCode: 401,
+                                      data: [.get: Data()])
+        failingProfileMock.register()
+
+        var refreshTokenMock = Mock(url: FakeService.FakeServiceURLs.refreshTokenURL,
+                                    dataType: .json,
+                                    statusCode: 200,
+                                    data: [.get: goodTokenData])
+
+        refreshTokenMock.onRequest = { _, _ in
+            // This won't help because it's too early.
+            // Removing the if-test means we are *assuming* that the refresh payload
+            // processing code worked, but that's part of the code under test so
+            // we do not want to do that.
+            if FakeService.accessToken.token == "good token" {
+                succeedingProfileMock.register()
+            }
+        }
+
+        refreshTokenMock.register()
+
+        // Now set up our dynamic mock that will replace the failingProfileMock
+        // with the succeedingProfileMock IFF we have a valid token (if the refreshToken call is made
+        // and gets a valid token)
+
+        //        Mocker.onMockFor = { _ in
+        //            if FakeService.accessToken.token == "good token" {
+        //                return succeedingProfileMock
+        //            } else { return nil }
+        //        }
+
+        let expectFailure = expectation(description: "call url - should get error")
+
+        // Now make the profile call that we expect will fail, internally
+        // get a new token from the service, and then retry and finally return us valid profile data.
+        service.profile(for: "JJ") { profile, error in
+            XCTAssertNil(error, "error is not nil!")
+            XCTAssertNotNil(profile, "profile is nil")
+            XCTAssertEqual(profile?.name, "Joe Jones", "profile name doesn't match")
+            expectFailure.fulfill()
+        }
+
+        wait(for: [expectFailure], timeout: 2.0)
+    }
 }
 
 // MARK: - Example Service Under Test -
@@ -168,4 +292,3 @@ class FakeService {
         }.resume()
     }
 }
-

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -482,6 +482,7 @@ final class MockerTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
     
+    /// It should call `onMockFor` to change the mock used for a url for subsequent fetches during the same test
     /// `onMockFor` can change the Mock used for a url for subsequent fetches during same test
     func testOnMockForConditionalReplacement() {
         var problemFixed = false    // imaginary problem flag

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -24,7 +24,7 @@ final class MockerTests: XCTestCase {
 		super.setUp()
 		
 		// make sure this is cleared before each test to avoid bleed-over between tests.
-		Mocker.shared.onMockFor = nil
+		Mocker.onMockFor = nil
 	}
     
     /// It should returned the register mocked image data as response.
@@ -414,7 +414,7 @@ final class MockerTests: XCTestCase {
         let url = URL(string: "https://www.fakeurl.com/DynamicTests")!
 		var onMockForCalled = false
 		
-		Mocker.shared.onMockFor = { (request: URLRequest) -> Mock? in
+		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
 			onMockForCalled = true
 			return nil
 		}
@@ -435,7 +435,7 @@ final class MockerTests: XCTestCase {
         let url = URL(string: "https://www.fakeurl.com")!
 		let injectedMockData = "{\"key\":\"value\"}".data(using: .utf8)!
 		
-		Mocker.shared.onMockFor = { (request: URLRequest) -> Mock? in
+		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
 			return Mock(dataType: .json, statusCode: 200, data: [.get: injectedMockData])
 		}
 		
@@ -461,7 +461,7 @@ final class MockerTests: XCTestCase {
         let url = URL(string: "https://www.fakeurl.com")!
 		let mockData = "{\"key\":\"value\"}".data(using: .utf8)!
 		
-		Mocker.shared.onMockFor = { (request: URLRequest) -> Mock? in
+		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
 			return nil
 		}
 		
@@ -496,7 +496,7 @@ final class MockerTests: XCTestCase {
 		// succeedingMock.register() - Do NOT call now as will replace failingMock.
 		// Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
 		
-		Mocker.shared.onMockFor = { _ in
+		Mocker.onMockFor = { _ in
 			if problemFixed {
 				return succeedingMock
 			} else { return nil }

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -456,7 +456,7 @@ final class MockerTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
     
-    /// `onMockFor` returning nil for non-matching replacement mock shouldn't change previous behavior
+    /// It should not change previous behavior when `onMockFor` returns `nil`.
     func testOnMockForReplacementReturnsNil() {
         let url = URL(string: "https://www.fakeurl.com")!
         let mockData = "{\"key\":\"value\"}".data(using: .utf8)!

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -520,7 +520,7 @@ final class MockerTests: XCTestCase {
         
         let expectSuccess = expectation(description: "call url again - should succeed")
         
-        // This retry should succeed becuase problemFixed is now true
+        // This retry should succeed because `problemFixed` is now `true`
         URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
             XCTAssertEqual(data, goodMockData)
             XCTAssertNotNil(urlresponse)

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -19,13 +19,13 @@ final class MockerTests: XCTestCase {
             owner = jsonDictionary["owner"] as? String
         }
     }
-	
-	override func setUp() {
-		super.setUp()
-		
-		// make sure this is cleared before each test to avoid bleed-over between tests.
-		Mocker.onMockFor = nil
-	}
+    
+    override func setUp() {
+        super.setUp()
+        
+        // make sure this is cleared before each test to avoid bleed-over between tests.
+        Mocker.onMockFor = nil
+    }
     
     /// It should returned the register mocked image data as response.
     func testImageURLDataRequest() {
@@ -409,125 +409,125 @@ final class MockerTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
-	/// It should call the `onMockFor` filter closure if set.
-	func testOnMockForFilterCalled() {
+    /// It should call the `onMockFor` filter closure if set.
+    func testOnMockForFilterCalled() {
         let url = URL(string: "https://www.fakeurl.com/DynamicTests")!
-		var onMockForCalled = false
-		
-		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
-			onMockForCalled = true
-			return nil
-		}
-		
+        var onMockForCalled = false
+        
+        Mocker.onMockFor = { (request: URLRequest) -> Mock? in
+            onMockForCalled = true
+            return nil
+        }
+        
         var mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
         let expectation = expectationForCompletingMock(&mock)
         mock.register()
-
-		URLSession.shared.dataTask(with: URLRequest(url: url)).resume()
-		
+        
+        URLSession.shared.dataTask(with: URLRequest(url: url)).resume()
+        
         wait(for: [expectation], timeout: 2.0)
-
-		XCTAssert(onMockForCalled, "our onMockFor handler was not called!")
-	}
-	
-	/// It should use the replacement mock set in the `onMockFor` filter closure
-	func testOnMockForReplacementMockUsed() {
+        
+        XCTAssert(onMockForCalled, "our onMockFor handler was not called!")
+    }
+    
+    /// It should use the replacement mock set in the `onMockFor` filter closure
+    func testOnMockForReplacementMockUsed() {
         let url = URL(string: "https://www.fakeurl.com")!
-		let injectedMockData = "{\"key\":\"value\"}".data(using: .utf8)!
-		
-		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
-			return Mock(dataType: .json, statusCode: 200, data: [.get: injectedMockData])
-		}
-		
-		let expectation = self.expectation(description: "Data request should succeed")
-
-		let mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
+        let injectedMockData = "{\"key\":\"value\"}".data(using: .utf8)!
+        
+        Mocker.onMockFor = { (request: URLRequest) -> Mock? in
+            return Mock(dataType: .json, statusCode: 200, data: [.get: injectedMockData])
+        }
+        
+        let expectation = self.expectation(description: "Data request should succeed")
+        
+        let mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
         mock.register()
-
-		URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
-
+        
+        URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
+            
             XCTAssertEqual(data, injectedMockData, "Data from injected mock not present")
             XCTAssertNotNil(urlresponse)
-			XCTAssertNil(err)
+            XCTAssertNil(err)
             
             expectation.fulfill()
         }.resume()
-		
+        
         wait(for: [expectation], timeout: 2.0)
-	}
-	
-	/// `onMockFor` returning nil for non-matching replacement mock shouldn't change previous behavior
-	func testOnMockForReplacementReturnsNil() {
+    }
+    
+    /// `onMockFor` returning nil for non-matching replacement mock shouldn't change previous behavior
+    func testOnMockForReplacementReturnsNil() {
         let url = URL(string: "https://www.fakeurl.com")!
-		let mockData = "{\"key\":\"value\"}".data(using: .utf8)!
-		
-		Mocker.onMockFor = { (request: URLRequest) -> Mock? in
-			return nil
-		}
-		
-		let expectation = self.expectation(description: "Data request should succeed")
-
-		let mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: mockData])
+        let mockData = "{\"key\":\"value\"}".data(using: .utf8)!
+        
+        Mocker.onMockFor = { (request: URLRequest) -> Mock? in
+            return nil
+        }
+        
+        let expectation = self.expectation(description: "Data request should succeed")
+        
+        let mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: mockData])
         mock.register()
-
-		URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
-
+        
+        URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
+            
             XCTAssertEqual(data, mockData, "Data from mock not present")
             XCTAssertNotNil(urlresponse)
-			XCTAssertNil(err)
+            XCTAssertNil(err)
             
             expectation.fulfill()
         }.resume()
-		
+        
         wait(for: [expectation], timeout: 2.0)
-	}
-	
-	/// `onMockFor` can change the Mock used for a url for subsequent fetches during same test
-	func testOnMockForConditionalReplacement() {
-		var problemFixed = false	// imaginary problem flag
-
-		let url = URL(string: "https://www.fakeurl.com/url1")!
-		let goodMockData = "good".data(using: .utf8)!
-		
-		let failingMock = Mock(url: url, dataType: .json, statusCode: 401, data: [.get: Data()])
-		failingMock.register()
-		
-		let succeedingMock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: goodMockData])
-		// succeedingMock.register() - Do NOT call now as will replace failingMock.
-		// Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
-		
-		Mocker.onMockFor = { _ in
-			if problemFixed {
-				return succeedingMock
-			} else { return nil }
-		}
-
-		let expectFailure = expectation(description: "call url - should get error")
-		
-		URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
-			XCTAssertNotNil(data)
-			XCTAssert((urlresponse as? HTTPURLResponse)?.statusCode == 401)
-			XCTAssertNil(err)
+    }
+    
+    /// `onMockFor` can change the Mock used for a url for subsequent fetches during same test
+    func testOnMockForConditionalReplacement() {
+        var problemFixed = false    // imaginary problem flag
+        
+        let url = URL(string: "https://www.fakeurl.com/url1")!
+        let goodMockData = "good".data(using: .utf8)!
+        
+        let failingMock = Mock(url: url, dataType: .json, statusCode: 401, data: [.get: Data()])
+        failingMock.register()
+        
+        let succeedingMock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: goodMockData])
+        // succeedingMock.register() - Do NOT call now as will replace failingMock.
+        // Instead, return `succeedingMock` using new `onMockFor` handler if problem is fixed:
+        
+        Mocker.onMockFor = { _ in
+            if problemFixed {
+                return succeedingMock
+            } else { return nil }
+        }
+        
+        let expectFailure = expectation(description: "call url - should get error")
+        
+        URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
+            XCTAssertNotNil(data)
+            XCTAssert((urlresponse as? HTTPURLResponse)?.statusCode == 401)
+            XCTAssertNil(err)
             
-			problemFixed = true		// Imagine problem was handled internally by library that
-									// then retries automatically (next call to same url)
+            problemFixed = true         // Imagine problem was handled internally by library that
+                                        // then retries automatically (next call to same url)
             expectFailure.fulfill()
         }.resume()
-
-		// Wait to call second "retry" fetch until first one returns.
+        
+        // Wait to call second "retry" fetch until first one returns.
         wait(for: [expectFailure], timeout: 2.0)
-
-		let expectSuccess = expectation(description: "call url again - should succeed")
-		
-		// This retry should succeed becuase problemFixed is now true
-		URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
+        
+        let expectSuccess = expectation(description: "call url again - should succeed")
+        
+        // This retry should succeed becuase problemFixed is now true
+        URLSession.shared.dataTask(with: URLRequest(url: url)) { (data, urlresponse, err) in
             XCTAssertEqual(data, goodMockData)
             XCTAssertNotNil(urlresponse)
-			XCTAssertNil(err)
-
+            XCTAssertNil(err)
+            
             expectSuccess.fulfill()
         }.resume()
-
+        
         wait(for: [expectSuccess], timeout: 2.0)
-	}
+    }
 }

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -85,26 +85,28 @@ public struct Mocker {
         }
     }
     
-    /// Retrieve a Mock for the given request. Matches on `request.url` and `request.httpMethod`.
-    /// if `onMockFor` is set, first see if that closure returns a mock; if it does, use that mock.
-    /// Otherwise, look for a specific mock that has been registered for this request.
-    /// If not found, check for a generic file extension mock.
+    /// Retrieve a Mock for the given request.
+    ///
+    /// Checks in order:
+    /// - If `onMockFor` set, execute with `request` and see if it returns a Mock to use.
+    /// - Check for Mock registered for `request.url` and `request.httpMethod`.
+    /// - Check for a generic file extension mock.
     ///
     /// - Parameter request: The request to search for a mock.
     /// - Returns: A mock if found, `nil` if there's no mocked data registered for the given request.
     static func mock(for request: URLRequest) -> Mock? {
         shared.queue.sync {
-            /// Zeroth support for dynamic mocks via `onMockFor` closure
+            // First, check if `onMockFor` closure provides a Mock to use for this request
             if let mockProvider = onMockFor,
                 let dynamicMock = mockProvider(request) {
                 return dynamicMock
             }
             
-            /// First check for specific URLs
+            // Second, check for specific URLs
             if let specificMock = shared.mocks.first(where: { $0 == request && $0.fileExtensions == nil }) {
                 return specificMock
             }
-            /// Second, check for generic file extension Mocks
+            // Third, check for generic file extension Mocks
             return shared.mocks.first(where: { $0 == request })
         }
     }

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -22,12 +22,18 @@ public struct Mocker {
     
     /// The HTTP Version to use in the mocked response.
     public static var httpVersion: HTTPVersion = HTTPVersion.http1_1
-    
+    	
 	/// Allow for dynamic Mocks.
-	/// If closure is assigned and a Mock is returned, that mock will override
+	/// If closure is set and a Mock is returned, that mock will override
 	/// any registered mocks and be used for the indicated request.
-	public var onMockFor: ((URLRequest) -> Mock?)?
+	public static var onMockFor: ((URLRequest) -> Mock?)? {
+		get { return shared.onMockForHandler }
+		set { shared.onMockForHandler = newValue }
+	}
 	
+	/// The saved onMockFor handler
+	internal var onMockForHandler: ((URLRequest) -> Mock?)?
+
     /// The registrated mocks.
     private(set) var mocks: [Mock] = []
     
@@ -89,7 +95,7 @@ public struct Mocker {
     static func mock(for request: URLRequest) -> Mock? {
         shared.queue.sync {
 			/// Zeroth support for dynamic mocks via `onMockFor` closure
-			if let mockProvider = shared.onMockFor,
+			if let mockProvider = onMockFor,
 				let dynamicMock = mockProvider(request) {
 					return dynamicMock
 			}

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -22,17 +22,17 @@ public struct Mocker {
     
     /// The HTTP Version to use in the mocked response.
     public static var httpVersion: HTTPVersion = HTTPVersion.http1_1
-    	
-	/// Allow for dynamic Mocks.
-	/// If closure is set and a Mock is returned, that mock will override
-	/// any registered mocks and be used for the indicated request.
-	public static var onMockFor: ((URLRequest) -> Mock?)? {
-		get { return shared.onMockForHandler }
-		set { shared.onMockForHandler = newValue }
-	}
-	
-	/// The saved onMockFor handler
-	internal var onMockForHandler: ((URLRequest) -> Mock?)?
+    
+    /// Allow for dynamic Mocks.
+    /// If closure is set and a Mock is returned, that mock will override
+    /// any registered mocks and be used for the indicated request.
+    public static var onMockFor: ((URLRequest) -> Mock?)? {
+        get { return shared.onMockForHandler }
+        set { shared.onMockForHandler = newValue }
+    }
+    
+    /// The saved onMockFor handler
+    internal var onMockForHandler: ((URLRequest) -> Mock?)?
 
     /// The registrated mocks.
     private(set) var mocks: [Mock] = []
@@ -87,19 +87,19 @@ public struct Mocker {
     
     /// Retrieve a Mock for the given request. Matches on `request.url` and `request.httpMethod`.
     /// if `onMockFor` is set, first see if that closure returns a mock; if it does, use that mock.
-	/// Otherwise, look for a specific mock that has been registered for this request.
-	/// If not found, check for a generic file extension mock.
-	///
+    /// Otherwise, look for a specific mock that has been registered for this request.
+    /// If not found, check for a generic file extension mock.
+    ///
     /// - Parameter request: The request to search for a mock.
     /// - Returns: A mock if found, `nil` if there's no mocked data registered for the given request.
     static func mock(for request: URLRequest) -> Mock? {
         shared.queue.sync {
-			/// Zeroth support for dynamic mocks via `onMockFor` closure
-			if let mockProvider = onMockFor,
-				let dynamicMock = mockProvider(request) {
-					return dynamicMock
-			}
-
+            /// Zeroth support for dynamic mocks via `onMockFor` closure
+            if let mockProvider = onMockFor,
+                let dynamicMock = mockProvider(request) {
+                return dynamicMock
+            }
+            
             /// First check for specific URLs
             if let specificMock = shared.mocks.first(where: { $0 == request && $0.fileExtensions == nil }) {
                 return specificMock

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -24,7 +24,7 @@ public struct Mocker {
     public static var httpVersion: HTTPVersion = HTTPVersion.http1_1
     
     /// Allow for dynamic Mocks.
-    /// If closure is set and a Mock is returned, that mock will override
+    /// If the closure is set and a Mock is returned, that mock will override
     /// any registered mocks and be used for the indicated request.
     public static var onMockFor: ((URLRequest) -> Mock?)? {
         get { return shared.onMockForHandler }


### PR DESCRIPTION
Sometimes you want the same URL to return different results at different times during a test - for example, an error payload first and then a success payload.

Dynamic Mock support enables this by allowing one to setup a closure (`onMockFor`) that gets called as a first step in mock matching (in Mocker's `mock(for request: URLRequest) -> Mock?`). If this closure returns a Mock, that is the mock returned from `mock(for …`) and is used to fulfill the mocked network request.

----

The particular use case I had was for a service call made with an expired token. The networking layer in this app will catch the expired token error, automatically make a refresh token service call, and then auto-retry the original service call.

In this situation I needed to have the mock for the original service call return a 401 for the expired token as long as the currentToken doesn't match the newGoodToken returned by the mocked refresh token call (which is auto-saved into currentToken by the networking layer).

So my (simplified) `onMockFor` will look something like this:


```
let refreshMock = Mock(url: refreshURL, dataType: .json, statusCode: 200, data: [.get: goodRefreshTokenData])
refreshMock.register()
let failureMock = Mock(url: serviceURL, dataType: .json, statusCode: 401, data: [.get, Data()])
failureMock.register()

let successMock = Mock(url: serviceURL, dataType: .json, statusCode: 200, data: [.get: goodMockData])
// Note: do not register! Will overwrite failureMock (same URL).

// Then add the `onMockFor` closure to check if we have the new token
Mocker.onMockFor = { (request: URLRequest) -> Mock? in
  guard request.url == serviceURL else { return nil }
  if currentToken == newGoodToken {
      return successMock
  }
  return nil
}
```
----

Seemed like it might be useful to others, and I'd rather not maintain our own custom fork of Mocker separate from yours, so I thought I'd open a PR for this feature in case you'd like to incorporate it in Mocker proper.  Tried to stick to your format and style and the majority of the code added is tests.  Happy to change things to make it work better for you. 
