### PR TITLE
Add ignoreQuery parameter to ignored urls

### DIFF
--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -260,7 +260,7 @@ final class MockerTests: XCTestCase {
         let ignoredURLQueries = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
 
         XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
-        Mocker.ignore(ignoredURL)
+        Mocker.ignore(ignoredURL, ignoreQuery: true)
         XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
     }
     

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -261,7 +261,7 @@ final class MockerTests: XCTestCase {
 
         XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
         Mocker.ignore(ignoredURL, ignoreQuery: true)
-        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
+        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == false)
     }
     
     /// It should be possible to compose a url relative to a base and still have it match the full url

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -252,6 +252,17 @@ final class MockerTests: XCTestCase {
         Mocker.ignore(ignoredURL)
         XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)) == false)
     }
+
+    /// It should be possible to ignore URLs and not let them be handled.
+    func testIgnoreURLsIgnoreQueries() {
+
+        let ignoredURL = URL(string: "https://www.wetransfer.com/sample-image.png")!
+        let ignoredURLQueries = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
+
+        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
+        Mocker.ignore(ignoredURL)
+        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
+    }
     
     /// It should be possible to compose a url relative to a base and still have it match the full url
     func testComposedURLMatch() {

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -197,7 +197,7 @@ public struct Mock: Equatable {
     }
 }
 
-private extension URL {
+extension URL {
     /// Returns the base URL string build with the scheme, host and path. "https://www.wetransfer.com/v1/test?param=test" would be "https://www.wetransfer.com/v1/test".
     var baseString: String? {
         guard let scheme = scheme, let host = host else { return nil }

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -10,7 +10,23 @@ import Foundation
 
 /// Can be used for registering Mocked data, returned by the `MockingURLProtocol`.
 public struct Mocker {
-    
+    private struct IgnoredRule: Equatable {
+        let urlToIgnore: URL
+        let ignoreQuery: Bool
+
+        /// Checks if the passed URL should be ignored.
+        ///
+        /// - Parameter url: The URL to check for.
+        /// - Returns: `true` if it should be ignored, `false` if the URL doesn't correspond to ignored rules.
+        func shouldIgnore(_ url: URL) -> Bool {
+            if ignoreQuery {
+                return urlToIgnore.baseString == url.baseString
+            }
+
+            return urlToIgnore.absoluteString == url.absoluteString
+        }
+    }
+
     public enum HTTPVersion: String {
         case http1_0 = "HTTP/1.0"
         case http1_1 = "HTTP/1.1"
@@ -32,23 +48,6 @@ public struct Mocker {
     }
 
     private var ignoredRules: [IgnoredRule] = []
-
-    private struct IgnoredRule: Equatable {
-        let urlToIgnore: URL
-        let ignoreQuery: Bool
-
-        /// Checks if the passed URL should be ignored.
-        ///
-        /// - Parameter url: The URL to check for.
-        /// - Returns: `true` if it should be ignored, `false` if the URL doesn't correspond to ignored rules.
-        func shouldIgnore(_ url: URL) -> Bool {
-            if ignoreQuery {
-                return urlToIgnore.baseString == url.baseString
-            }
-
-            return urlToIgnore.absoluteString == url.absoluteString
-        }
-    }
 
     /// For Thread Safety access.
     private let queue = DispatchQueue(label: "mocker.mocks.access.queue", attributes: .concurrent)

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -37,11 +37,11 @@ public struct Mocker {
         let urlToIgnore: URL
         let ignoreQuery: Bool
 
-        /// Checks if the passed URL should be handled by the Mocker.
+        /// Checks if the passed URL should be ignored.
         ///
         /// - Parameter url: The URL to check for.
-        /// - Returns: `true` if it should be mocked, `false` if the URL is registered as ignored.
-        func shouldHandle(_ url: URL) -> Bool {
+        /// - Returns: `true` if it should be ignored, `false` if the URL doesn't correspond to ignored rules.
+        func shouldIgnore(_ url: URL) -> Bool {
             if ignoreQuery {
                 return urlToIgnore.baseString == url.baseString
             }
@@ -86,11 +86,7 @@ public struct Mocker {
     /// - Returns: `true` if it should be mocked, `false` if the URL is registered as ignored.
     public static func shouldHandle(_ url: URL) -> Bool {
         shared.queue.sync {
-            guard let rule = shared.ignoredRules.first(where: { $0.urlToIgnore == url }) else {
-                return true // No rule was found, it should be mocked
-            }
-
-            return rule.shouldHandle(url)
+            return !shared.ignoredRules.contains(where: { $0.shouldIgnore(url) })
         }
     }
 


### PR DESCRIPTION
This PR adds the `ignoreQuery` parameters like the one on `Mock` objects for ignored urls.

Because we may need to ignore urls with timestamps also.