### PR TITLE
Updated README.md to resolve build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ let package = Package(
 
 To add Mocker as a [dependency](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) to your Xcode project, select *File > Swift Packages > Add Package Dependency* and enter the repository URL.
 
+#### Resolving Build Errors
+If you get the following error: *cannot find auto-link library XCTest and XCTestSwiftSupport*, set the following property under Build Options from No to Yes.  
+ENABLE_TESTING_SEARCH_PATHS to YES
+
 ### Manually
 
 If you prefer not to use any of the aforementioned dependency managers, you can integrate Mocker into your project manually.


### PR DESCRIPTION
After adding Mocker via SPM, I spend hours trying to figure out why XCTest and XCTestSwiftSupport didn't link. Wanted to save others pain and added instructions to update Build Options, ENABLE_TESTING_SEARCH_PATHS to YES.

For reference found the proposed solution here
https://forums.swift.org/t/the-error-cannot-find-auto-link-library-xctest-and-xctestswiftsupport/34785

Note, this resolves linking errors in run/debug. Errors will persist if Mocker is included in archive/release. Up to user to resolve, and I assume user would exclude Mocker in archive/release. 