### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
-    pod 'Mocker', '~> 2.3.0'
+    pod 'Mocker', '~> 2.2.0'
 end
 ```
 


### PR DESCRIPTION
Attempting to install version 2.3.0 results in errors.

[!] CocoaPods could not find compatible versions for pod "Mocker":
  In Podfile:
    Mocker (~> 2.3.0)

None of your spec sources contain a spec satisfying the dependency: `Mocker (~> 2.3.0)`.

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.