### PR TITLE
feat: Global mode to choose only to mock registered routes

### DIFF
--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -441,4 +441,58 @@ final class MockerTests: XCTestCase {
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
+
+    /// It should process unknown URL
+    func testMockerOptoutMode() {
+        Mocker.mode = .optout
+
+        let mockedURL = URL(string: "www.google.com")!
+        let ignoredURL = URL(string: "www.wetransfer.com")!
+        let unknownURL = URL(string: "www.netflix.com")!
+
+        // Mocking
+        Mock(url: mockedURL, dataType: .json, statusCode: 200, data: [.get: Data()])
+            .register()
+
+        // Ignoring
+        Mocker.ignore(ignoredURL)
+
+        // Checking mocked URL are processed by Mocker
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: mockedURL)))
+        // Checking ignored URL are not processed by Mocker
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
+
+        // Checking unknown URL are processed by Mocker (.optout mode)
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: unknownURL)))
+    }
+
+    /// It should not process unknown URL
+    func testMockerOptinMode() {
+        Mocker.mode = .optin
+
+        let mockedURL = URL(string: "www.google.com")!
+        let ignoredURL = URL(string: "www.wetransfer.com")!
+        let unknownURL = URL(string: "www.netflix.com")!
+
+        // Mocking
+        Mock(url: mockedURL, dataType: .json, statusCode: 200, data: [.get: Data()])
+            .register()
+
+        // Ignoring
+        Mocker.ignore(ignoredURL)
+
+        // Checking mocked URL are processed by Mocker
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: mockedURL)))
+        // Checking ignored URL are not processed by Mocker
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
+
+        // Checking unknown URL are not processed by Mocker (.optin mode)
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: unknownURL)))
+    }
+
+    /// Default mode should be .optout
+    func testDefaultMode() {
+        /// Checking default mode
+        XCTAssertEqual(.optout, Mocker.mode)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -181,11 +181,23 @@ Mock(url: URL(string: "https://wetransfer.com/redirect")!, dataType: .json, stat
 ```
 
 ##### Ignoring URLs
-As the Mocker catches all URLs when registered, you might end up with a `fatalError` thrown in cases you don't need a mocked request. In that case you can ignore the URL:
+As the Mocker catches all URLs by default when registered, you might end up with a `fatalError` thrown in cases you don't need a mocked request. In that case you can ignore the URL:
 
 ```swift
 let ignoredURL = URL(string: "www.wetransfer.com")!
 Mocker.ignore(ignoredURL)
+```
+
+However if you need the Mocker to catch only mocked URLs and ignore every other URL, you can set the `mode` attribute to `.optin`. 
+
+```swift
+Mocker.mode = .optin
+```
+
+If you want to set the original mode back, you have juste to set it to `.optout`.
+
+```swift
+Mocker.mode = .optout
 ```
 
 ##### Mock errors

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ However if you need the Mocker to catch only mocked URLs and ignore every other 
 Mocker.mode = .optin
 ```
 
-If you want to set the original mode back, you have juste to set it to `.optout`.
+If you want to set the original mode back, you have just to set it to `.optout`.
 
 ```swift
 Mocker.mode = .optout

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -33,8 +33,24 @@ public struct Mocker {
         case http2_0 = "HTTP/2.0"
     }
 
-    /// The way Mocker handles unknown URLs
-    public static var mode : Mode = .optout
+    /// The way Mocker handles unregistered urls
+    public enum Mode {
+        /// The default mode: only URLs registered with the `ignore(_ url: URL)` method are ignored for mocking.
+        ///
+        /// - Registered mocked URL: Mocked.
+        /// - Registered ignored URL: Ignored by Mocker, default process is applied as if the Mocker doesn't exist.
+        /// - Any other URL: Raises an error.
+        case optout
+
+        /// Only registered mocked URLs are mocked, all others pass through.
+        ///
+        /// - Registered mocked URL: Mocked.
+        /// - Any other URL: Ignored by Mocker, default process is applied as if the Mocker doesn't exist.
+        case optin
+    }
+
+    /// The mode defines how unknown URLs are handled. Defaults to `optout` which means requests without a mock will fail.
+    public static var mode: Mode = .optout
 
     /// The shared instance of the Mocker, can be used to register and return mocks.
     internal static var shared = Mocker()
@@ -115,21 +131,5 @@ public struct Mocker {
             /// Second, check for generic file extension Mocks
             return shared.mocks.first(where: { $0 == request })
         }
-    }
-
-    /// The way Mocker handles unregistered urls
-    public enum Mode {
-        /// The default mode: only URLs registered with the `ignore(_ url: URL)` method are ignored for mocking.
-        ///
-        /// - Registered mocked URL: Mocked.
-        /// - Registered ignored URL: Ignored by Mocker, default process is applied as if the Mocker doesn't exist.
-        /// - Any other URL: Raises an error.
-        case optout
-
-        /// Only registered mocked URLs are mocked, all others pass through.
-        ///
-        /// - Registered mocked URL: Mocked.
-        /// - Any other URL: Ignored by Mocker, default process is applied as if the Mocker doesn't exist.
-        case optin
     }
 }

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -105,8 +105,10 @@ public struct Mocker {
     public static func shouldHandle(_ url: URL) -> Bool {
         shared.queue.sync {
             switch mode {
-            case .optout: return !shared.ignoredRules.contains(where: { $0.shouldIgnore(url) })
-            case .optin: return shared.mocks.contains(where: { $0.url == url })
+            case .optout:
+                return !shared.ignoredRules.contains(where: { $0.shouldIgnore(url) })
+            case .optin:
+                return shared.mocks.contains(where: { $0.url == url })
             }
         }
     }


### PR DESCRIPTION
Hello,
This is my first time contribution ever.
Yesterday I wrote a question / feature request for our needs: https://github.com/WeTransfer/Mocker/issues/83

After checking out the source, I found an easy way to integrate this feature without changing the current way it works. So I propose a Pull request to integrate it.

This feature adds a new property to the `Mocker` struct called `mode`. By default the current mode is `.optout` meaning you have to manually define all the routes you want the system to ignore and thus to process as if the mocker does not exist.  This is the way it works today. The other mode is `.optin` used to let all the routes being processed as if there were no mocking system, except for the mocked routes.

The use case leading to this feature is when you have an existing API with many routes, and a team has to develop a new route, for your development phase, you can mock only this route, to keep using you app and all the other routes in a complete transparent way.

I hope you'll find this useful. 