### PR TITLE
Make sure file extension mocks are matching correctly

### DIFF
--- a/MockerTests/MockTests.swift
+++ b/MockerTests/MockTests.swift
@@ -1,0 +1,35 @@
+//
+//  MockTests.swift
+//  
+//
+//  Created by Antoine van der Lee on 21/04/2021.
+//
+
+import Foundation
+import XCTest
+@testable import Mocker
+
+final class MockTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Mocker.mode = .optout
+    }
+    
+    override func tearDown() {
+        Mocker.removeAll()
+        Mocker.mode = .optout
+        super.tearDown()
+    }
+    
+    /// It should match two file extension mocks correctly.
+    func testFileExtensionMocksComparing() {
+        let mock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        let secondMock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        let mock400 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 400, data: [.put: Data()])
+        let mockJPEG = Mock(fileExtensions: "jpeg", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        
+        XCTAssertEqual(mock200, secondMock200)
+        XCTAssertEqual(mock200, mock400)
+        XCTAssertNotEqual(mock200, mockJPEG)
+    }
+}

--- a/MockerTests/MockTests.swift
+++ b/MockerTests/MockTests.swift
@@ -1,6 +1,6 @@
 //
 //  MockTests.swift
-//  
+//
 //
 //  Created by Antoine van der Lee on 21/04/2021.
 //

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(name: "Mocker",
                         ],
                       targets: [
                         // dev .target(name: "DangerDependencies", dependencies: ["Danger", "WeTransferPRLinter"], path: "Submodules/WeTransfer-iOS-CI/Danger-Swift", sources: ["DangerFakeSource.swift"]),
-                        .target(name: "Mocker", path: "Sources")
+                        .target(name: "Mocker", path: "Sources"),
+                        .testTarget(name: "MockerTests", dependencies: ["Mocker"], path: "MockerTests")
                         ],
                       swiftLanguageVersions: [.v5])

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -205,6 +205,12 @@ public struct Mock: Equatable {
     public static func == (lhs: Mock, rhs: Mock) -> Bool {
         let lhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }
         let rhsHTTPMethods: [String] = rhs.data.keys.compactMap { $0.rawValue }
+        
+        if let lhsFileExtensions = lhs.fileExtensions, let rhsFileExtensions = rhs.fileExtensions, (!lhsFileExtensions.isEmpty || !rhsFileExtensions.isEmpty) {
+            /// The mocks are targeting file extensions specifically, check on those.
+            return lhsFileExtensions == rhsFileExtensions && lhsHTTPMethods == rhsHTTPMethods
+        }
+        
         return lhs.request.url!.absoluteString == rhs.request.url!.absoluteString && lhsHTTPMethods == rhsHTTPMethods
     }
 }


### PR DESCRIPTION
Mocks targetting file extensions weren't matching correctly.