### PR TITLE
Improve test expressivity

### DIFF
--- a/MockerTests/MockTests.swift
+++ b/MockerTests/MockTests.swift
@@ -14,20 +14,20 @@ final class MockTests: XCTestCase {
         super.setUp()
         Mocker.mode = .optout
     }
-    
+
     override func tearDown() {
         Mocker.removeAll()
         Mocker.mode = .optout
         super.tearDown()
     }
-    
+
     /// It should match two file extension mocks correctly.
     func testFileExtensionMocksComparing() {
         let mock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
         let secondMock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
         let mock400 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 400, data: [.put: Data()])
         let mockJPEG = Mock(fileExtensions: "jpeg", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
-        
+
         XCTAssertEqual(mock200, secondMock200)
         XCTAssertEqual(mock200, mock400)
         XCTAssertNotEqual(mock200, mockJPEG)

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -13,64 +13,64 @@ final class MockerTests: XCTestCase {
     struct Framework {
         let name: String?
         let owner: String?
-        
+
         init(jsonDictionary: [String: Any]) {
             name = jsonDictionary["name"] as? String
             owner = jsonDictionary["owner"] as? String
         }
     }
-    
+
     override func setUp() {
         super.setUp()
         Mocker.mode = .optout
     }
-    
+
     override func tearDown() {
         Mocker.removeAll()
         Mocker.mode = .optout
         super.tearDown()
     }
-    
+
     /// It should returned the register mocked image data as response.
     func testImageURLDataRequest() {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://avatars3.githubusercontent.com/u/26250426?v=4&s=400")!
-        
+
         let mock = Mock(url: originalURL, dataType: .imagePNG, statusCode: 200, data: [
             .get: MockedData.botAvatarImageFileUrl.data
         ])
-        
+
         mock.register()
         URLSession.shared.dataTask(with: originalURL) { (data, _, error) in
             XCTAssertNil(error)
             let image: UIImage = UIImage(data: data!)!
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
-            
+
             XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should returned the register mocked image data as response for register file types.
     func testImageExtensionDataRequest() {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png")
-        
+
         Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [
             .get: MockedData.botAvatarImageFileUrl.data
         ]).register()
-        
+
         URLSession.shared.dataTask(with: originalURL!) { (data, _, error) in
             XCTAssertNil(error)
             let image: UIImage = UIImage(data: data!)!
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
-            
+
             XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
@@ -136,17 +136,17 @@ final class MockerTests: XCTestCase {
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should return the mocked JSON.
     func testJSONRequest() {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/example.json")!
-        
+
         Mock(url: originalURL, dataType: .json, statusCode: 200, data: [
             .get: MockedData.exampleJSON.data
-            ]
+        ]
         ).register()
-        
+
         URLSession.shared.dataTask(with: originalURL) { (data, _, _) in
 
             guard let data = data else {
@@ -159,64 +159,64 @@ final class MockerTests: XCTestCase {
                 expectation.fulfill()
                 return
             }
-            
+
             let framework = Framework(jsonDictionary: jsonDictionary)
             XCTAssertEqual(framework.name, "Mocker")
             XCTAssertEqual(framework.owner, "WeTransfer")
-            
+
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should return the additional headers.
     func testAdditionalHeaders() {
         let expectation = self.expectation(description: "Data request should succeed")
         let headers = ["testkey": "testvalue"]
         let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: headers)
         mock.register()
-        
+
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
             XCTAssertNil(error)
             XCTAssertEqual(((response as? HTTPURLResponse)?.allHeaderFields["testkey"] as? String), "testvalue", "Additional headers should be added.")
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should override existing mocks.
     func testMockOverriding() {
         let expectation = self.expectation(description: "Data request should succeed")
         let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["testkey": "testvalue"])
         mock.register()
-        
+
         let newMock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["newkey": "newvalue"])
         newMock.register()
-        
+
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
             XCTAssertNil(error)
             XCTAssertEqual(((response as? HTTPURLResponse)?.allHeaderFields["newkey"] as? String), "newvalue", "Additional headers should be added.")
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should work with a custom URLSession.
     func testCustomURLSession() {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png")
-        
+
         Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [
             .get: MockedData.botAvatarImageFileUrl.data
         ]).register()
-        
+
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self]
         let urlSession = URLSession(configuration: configuration)
-        
+
         urlSession.dataTask(with: originalURL!) { (data, _, error) in
             XCTAssertNil(error)
             guard let data = data else {
@@ -229,43 +229,43 @@ final class MockerTests: XCTestCase {
                 return
             }
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
-            
+
             XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
-            }.resume()
-        
+        }.resume()
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should be possible to test cancellation of requests with a delayed mock.
     func testDelayedMockCancelation() {
         let expectation = self.expectation(description: "Data request should be cancelled")
         var mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
         mock.delay = DispatchTimeInterval.seconds(5)
         mock.register()
-        
+
         let task = URLSession.shared.dataTask(with: mock.request) { (_, _, error) in
             XCTAssertEqual(error?._code, NSURLErrorCancelled)
             expectation.fulfill()
         }
-        
+
         task.resume()
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
             task.cancel()
         })
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should correctly handle redirect responses.
     func testRedirectResponse() {
         let expectation = self.expectation(description: "Data request should be cancelled")
         let urlWhichRedirects: URL = URL(string: "https://we.tl/redirect")!
         Mock(url: urlWhichRedirects, dataType: .html, statusCode: 200, data: [.get: MockedData.redirectGET.data]).register()
         Mock(url: URL(string: "https://wetransfer.com/redirect")!, dataType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data]).register()
-        
+
         URLSession.shared.dataTask(with: urlWhichRedirects) { (data, _, _) in
-            
+
             guard let data = data else {
                 XCTFail("Data is nil")
                 return
@@ -276,22 +276,22 @@ final class MockerTests: XCTestCase {
                 expectation.fulfill()
                 return
             }
-            
+
             let framework = Framework(jsonDictionary: jsonDictionary)
             XCTAssertEqual(framework.name, "Mocker")
             XCTAssertEqual(framework.owner, "WeTransfer")
-            
+
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
-    
+
     /// It should be possible to ignore URLs and not let them be handled.
     func testIgnoreURLs() {
-        
+
         let ignoredURL = URL(string: "www.wetransfer.com")!
-        
+
         XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
         Mocker.ignore(ignoredURL)
         XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
@@ -307,7 +307,7 @@ final class MockerTests: XCTestCase {
         Mocker.ignore(ignoredURL, ignoreQuery: true)
         XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)))
     }
-    
+
     /// It should be possible to compose a url relative to a base and still have it match the full url
     func testComposedURLMatch() {
         let composedURL = URL(fileURLWithPath: "resource", relativeTo: URL(string: "https://host.com/api/"))
@@ -427,7 +427,7 @@ final class MockerTests: XCTestCase {
 
         wait(for: [expectation], timeout: 2.0)
     }
-    
+
     /// it should return the error we requested from the mock when we pass in an Error.
     func testMockReturningError() {
         let expectation = self.expectation(description: "Data request should succeed")
@@ -435,12 +435,12 @@ final class MockerTests: XCTestCase {
 
         enum TestExampleError: Error, LocalizedError {
             case example
-            
+
             var errorDescription: String { "example" }
         }
-        
+
         Mock(url: originalURL, dataType: .json, statusCode: 500, data: [.get: Data()], requestError: TestExampleError.example).register()
-        
+
         URLSession.shared.dataTask(with: originalURL) { (data, urlresponse, error) in
 
             XCTAssertNil(data)
@@ -452,10 +452,10 @@ final class MockerTests: XCTestCase {
                 // purposes
                 XCTAssertTrue(String(describing: error).contains("TestExampleError"))
             }
-            
+
             expectation.fulfill()
         }.resume()
-        
+
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -88,7 +88,11 @@ final class MockerTests: XCTestCase {
 
         URLSession.shared.dataTask(with: originalURL) { (data, _, error) in
             XCTAssertNil(error)
-            guard let data = data, let image: UIImage = UIImage(data: data) else {
+            guard let data = data else {
+                XCTFail("Data is nil")
+                return
+            }
+            guard let image: UIImage = UIImage(data: data) else {
                 XCTFail("Invalid data \(String(describing: data))")
                 return
             }
@@ -115,7 +119,12 @@ final class MockerTests: XCTestCase {
 
         URLSession.shared.dataTask(with: customURL) { (data, _, error) in
             XCTAssertNil(error)
-            guard let data = data, let image: UIImage = UIImage(data: data) else {
+            guard let data = data else {
+                XCTFail("Data is nil")
+                return
+            }
+
+            guard let image: UIImage = UIImage(data: data) else {
                 XCTFail("Invalid data \(String(describing: data))")
                 return
             }
@@ -140,7 +149,12 @@ final class MockerTests: XCTestCase {
         
         URLSession.shared.dataTask(with: originalURL) { (data, _, _) in
 
-            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            guard let data = data else {
+                XCTFail("Data is nil")
+                return
+            }
+
+            guard let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
                 XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return
@@ -205,7 +219,12 @@ final class MockerTests: XCTestCase {
         
         urlSession.dataTask(with: originalURL!) { (data, _, error) in
             XCTAssertNil(error)
-            guard let data = data, let image: UIImage = UIImage(data: data) else {
+            guard let data = data else {
+                XCTFail("Data is nil")
+                return
+            }
+
+            guard let image: UIImage = UIImage(data: data) else {
                 XCTFail("Invalid data \(String(describing: data))")
                 return
             }
@@ -247,7 +266,12 @@ final class MockerTests: XCTestCase {
         
         URLSession.shared.dataTask(with: urlWhichRedirects) { (data, _, _) in
             
-            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            guard let data = data else {
+                XCTFail("Data is nil")
+                return
+            }
+
+            guard let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
                 XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -42,11 +42,11 @@ final class MockerTests: XCTestCase {
         
         mock.register()
         URLSession.shared.dataTask(with: originalURL) { (data, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
             let image: UIImage = UIImage(data: data!)!
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
             
-            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
         
@@ -63,11 +63,11 @@ final class MockerTests: XCTestCase {
         ]).register()
         
         URLSession.shared.dataTask(with: originalURL!) { (data, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
             let image: UIImage = UIImage(data: data!)!
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
             
-            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
         
@@ -87,14 +87,14 @@ final class MockerTests: XCTestCase {
         ]).register()
 
         URLSession.shared.dataTask(with: originalURL) { (data, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
             guard let data = data, let image: UIImage = UIImage(data: data) else {
-                XCTFail("Invalid data")
+                XCTFail("Invalid data \(String(describing: data))")
                 return
             }
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
 
-            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
 
@@ -114,14 +114,14 @@ final class MockerTests: XCTestCase {
         let customURL = URL(string: originalURL.absoluteString + "&" + UUID().uuidString)!
 
         URLSession.shared.dataTask(with: customURL) { (data, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
             guard let data = data, let image: UIImage = UIImage(data: data) else {
-                XCTFail("Invalid data")
+                XCTFail("Invalid data \(String(describing: data))")
                 return
             }
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
 
-            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
         }.resume()
 
@@ -141,14 +141,14 @@ final class MockerTests: XCTestCase {
         URLSession.shared.dataTask(with: originalURL) { (data, _, _) in
 
             guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
-                XCTFail("Wrong data response")
+                XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return
             }
             
             let framework = Framework(jsonDictionary: jsonDictionary)
-            XCTAssert(framework.name == "Mocker")
-            XCTAssert(framework.owner == "WeTransfer")
+            XCTAssertEqual(framework.name, "Mocker")
+            XCTAssertEqual(framework.owner, "WeTransfer")
             
             expectation.fulfill()
         }.resume()
@@ -164,8 +164,8 @@ final class MockerTests: XCTestCase {
         mock.register()
         
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
-            XCTAssert(error == nil)
-            XCTAssert(((response as! HTTPURLResponse).allHeaderFields["testkey"] as! String) == "testvalue", "Additional headers should be added.")
+            XCTAssertNil(error)
+            XCTAssertEqual(((response as? HTTPURLResponse)?.allHeaderFields["testkey"] as? String), "testvalue", "Additional headers should be added.")
             expectation.fulfill()
         }.resume()
         
@@ -182,8 +182,8 @@ final class MockerTests: XCTestCase {
         newMock.register()
         
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
-            XCTAssert(error == nil)
-            XCTAssert(((response as! HTTPURLResponse).allHeaderFields["newkey"] as! String) == "newvalue", "Additional headers should be added.")
+            XCTAssertNil(error)
+            XCTAssertEqual(((response as? HTTPURLResponse)?.allHeaderFields["newkey"] as? String), "newvalue", "Additional headers should be added.")
             expectation.fulfill()
         }.resume()
         
@@ -204,14 +204,14 @@ final class MockerTests: XCTestCase {
         let urlSession = URLSession(configuration: configuration)
         
         urlSession.dataTask(with: originalURL!) { (data, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
             guard let data = data, let image: UIImage = UIImage(data: data) else {
-                XCTFail("Invalid data")
+                XCTFail("Invalid data \(String(describing: data))")
                 return
             }
             let sampleImage: UIImage = UIImage(contentsOfFile: MockedData.botAvatarImageFileUrl.path)!
             
-            XCTAssert(image.size == sampleImage.size, "Image should be returned mocked")
+            XCTAssertEqual(image.size, sampleImage.size, "Image should be returned mocked")
             expectation.fulfill()
             }.resume()
         
@@ -226,7 +226,7 @@ final class MockerTests: XCTestCase {
         mock.register()
         
         let task = URLSession.shared.dataTask(with: mock.request) { (_, _, error) in
-            XCTAssert(error?._code == NSURLErrorCancelled)
+            XCTAssertEqual(error?._code, NSURLErrorCancelled)
             expectation.fulfill()
         }
         
@@ -248,14 +248,14 @@ final class MockerTests: XCTestCase {
         URLSession.shared.dataTask(with: urlWhichRedirects) { (data, _, _) in
             
             guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
-                XCTFail("Wrong data response")
+                XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return
             }
             
             let framework = Framework(jsonDictionary: jsonDictionary)
-            XCTAssert(framework.name == "Mocker")
-            XCTAssert(framework.owner == "WeTransfer")
+            XCTAssertEqual(framework.name, "Mocker")
+            XCTAssertEqual(framework.owner, "WeTransfer")
             
             expectation.fulfill()
         }.resume()
@@ -268,9 +268,9 @@ final class MockerTests: XCTestCase {
         
         let ignoredURL = URL(string: "www.wetransfer.com")!
         
-        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)) == true)
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
         Mocker.ignore(ignoredURL)
-        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)) == false)
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
     }
 
     /// It should be possible to ignore URLs and not let them be handled.
@@ -279,9 +279,9 @@ final class MockerTests: XCTestCase {
         let ignoredURL = URL(string: "https://www.wetransfer.com/sample-image.png")!
         let ignoredURLQueries = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
 
-        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == true)
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)))
         Mocker.ignore(ignoredURL, ignoreQuery: true)
-        XCTAssert(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)) == false)
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)))
     }
     
     /// It should be possible to compose a url relative to a base and still have it match the full url
@@ -290,7 +290,7 @@ final class MockerTests: XCTestCase {
         let simpleURL = URL(string: "https://host.com/api/resource")
         let mock = Mock(url: composedURL, dataType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data])
         let urlRequest = URLRequest(url: simpleURL!)
-        XCTAssertEqual(composedURL.absoluteString, simpleURL!.absoluteString)
+        XCTAssertEqual(composedURL.absoluteString, simpleURL?.absoluteString)
         XCTAssert(mock == urlRequest)
     }
 
@@ -350,7 +350,7 @@ final class MockerTests: XCTestCase {
         }
         nonDelayMock.register()
 
-        XCTAssertNotEqual(delayedMock.request.url!, nonDelayMock.request.url!)
+        XCTAssertNotEqual(delayedMock.request.url, nonDelayMock.request.url)
 
         URLSession.shared.dataTask(with: delayedMock.request).resume()
         URLSession.shared.dataTask(with: nonDelayMock.request).resume()
@@ -452,7 +452,7 @@ final class MockerTests: XCTestCase {
         let urlSession = URLSession(configuration: configuration)
 
         urlSession.dataTask(with: originalURL) { (_, _, error) in
-            XCTAssert(error == nil)
+            XCTAssertNil(error)
 
             let cachedResponse = configuration.urlCache?.cachedResponse(for: URLRequest(url: originalURL))
             XCTAssertNotNil(cachedResponse)

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -140,7 +140,7 @@ final class MockerTests: XCTestCase {
         
         URLSession.shared.dataTask(with: originalURL) { (data, _, _) in
 
-            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
                 XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return
@@ -247,7 +247,7 @@ final class MockerTests: XCTestCase {
         
         URLSession.shared.dataTask(with: urlWhichRedirects) { (data, _, _) in
             
-            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+            guard let data = data, let jsonDictionary = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
                 XCTFail("Wrong data response \(String(describing: data))")
                 expectation.fulfill()
                 return

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -28,7 +28,7 @@ public struct Mock: Equatable {
         case trace   = "TRACE"
         case connect = "CONNECT"
     }
-    
+
     /// The types of content of a request. Will be used as Content-Type header inside a `Mock`.
     public enum DataType: String {
         case json
@@ -37,7 +37,7 @@ public struct Mock: Equatable {
         case pdf
         case mp4
         case zip
-        
+
         var headerValue: String {
             switch self {
             case .json:
@@ -57,19 +57,19 @@ public struct Mock: Equatable {
     }
 
     public typealias OnRequest = (_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> Void
-    
+
     /// The type of the data which is returned.
     public let dataType: DataType
-    
+
     /// If set, the error that URLProtocol will report as a result rather than returning data from the mock
     public let requestError: Error?
 
     /// The headers to send back with the response.
     public let headers: [String: String]
-    
+
     /// The HTTP status code to return with the response.
     public let statusCode: Int
-    
+
     /// The URL value generated based on the Mock data. Force unwrapped on purpose. If you access this URL while it's not set, this is a programming error.
     public var url: URL {
         if urlToMock == nil && !data.keys.contains(.get) {
@@ -89,13 +89,13 @@ public struct Mock: Equatable {
 
     /// If `true`, checking the URL will ignore the query and match only for the scheme, host and path.
     public let ignoreQuery: Bool
-    
+
     /// The file extensions to match for.
     public let fileExtensions: [String]?
-    
+
     /// The data which will be returned as the response based on the HTTP Method.
     private let data: [HTTPMethod: Data]
-    
+
     /// Add a delay to a certain mock, which makes the response returned later.
     public var delay: DispatchTimeInterval?
 
@@ -113,7 +113,7 @@ public struct Mock: Equatable {
 
     /// Can only be set internally as it's used by the `expectationForCompletingMock(_:)` method.
     var onCompletedExpectation: XCTestExpectation?
-    
+
     private init(url: URL? = nil, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], requestError: Error? = nil, additionalHeaders: [String: String] = [:], fileExtensions: [String]? = nil) {
         self.urlToMock = url
         let generatedURL = URL(string: "https://mocked.wetransfer.com/\(dataType.rawValue)/\(statusCode)/\(data.keys.first!.rawValue)")!
@@ -134,7 +134,7 @@ public struct Mock: Equatable {
 
         self.fileExtensions = fileExtensions?.map({ $0.replacingOccurrences(of: ".", with: "") })
     }
-    
+
     /// Creates a `Mock` for the given data type. The mock will be automatically matched based on a URL created from the given parameters.
     ///
     /// - Parameters:
@@ -145,7 +145,7 @@ public struct Mock: Equatable {
     public init(dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
         self.init(url: nil, dataType: dataType, statusCode: statusCode, data: data, additionalHeaders: additionalHeaders, fileExtensions: nil)
     }
-    
+
     /// Creates a `Mock` for the given URL.
     ///
     /// - Parameters:
@@ -160,7 +160,7 @@ public struct Mock: Equatable {
     public init(url: URL, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:], requestError: Error? = nil) {
         self.init(url: url, ignoreQuery: ignoreQuery, cacheStoragePolicy: cacheStoragePolicy, dataType: dataType, statusCode: statusCode, data: data, requestError: requestError, additionalHeaders: additionalHeaders, fileExtensions: nil)
     }
-    
+
     /// Creates a `Mock` for the given file extensions. The mock will only be used for urls matching the extension.
     ///
     /// - Parameters:
@@ -172,12 +172,12 @@ public struct Mock: Equatable {
     public init(fileExtensions: String..., dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
         self.init(url: nil, dataType: dataType, statusCode: statusCode, data: data, additionalHeaders: additionalHeaders, fileExtensions: fileExtensions)
     }
-    
+
     /// Registers the mock with the shared `Mocker`.
     public func register() {
         Mocker.register(self)
     }
-    
+
     /// Returns `Data` based on the HTTP Method of the passed request.
     ///
     /// - Parameter request: The request to match data for.
@@ -186,11 +186,11 @@ public struct Mock: Equatable {
         guard let requestHTTPMethod = Mock.HTTPMethod(rawValue: request.httpMethod ?? "") else { return nil }
         return data[requestHTTPMethod]
     }
-    
+
     /// Used to compare the Mock data with the given `URLRequest`.
     static func == (mock: Mock, request: URLRequest) -> Bool {
         guard let requestHTTPMethod = Mock.HTTPMethod(rawValue: request.httpMethod ?? "") else { return false }
-        
+
         if let fileExtensions = mock.fileExtensions {
             // If the mock contains a file extension, this should always be used to match for.
             guard let pathExtension = request.url?.pathExtension else { return false }
@@ -201,16 +201,16 @@ public struct Mock: Equatable {
 
         return mock.request.url!.absoluteString == request.url?.absoluteString && mock.data.keys.contains(requestHTTPMethod)
     }
-    
+
     public static func == (lhs: Mock, rhs: Mock) -> Bool {
         let lhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }
         let rhsHTTPMethods: [String] = rhs.data.keys.compactMap { $0.rawValue }
-        
+
         if let lhsFileExtensions = lhs.fileExtensions, let rhsFileExtensions = rhs.fileExtensions, (!lhsFileExtensions.isEmpty || !rhsFileExtensions.isEmpty) {
             /// The mocks are targeting file extensions specifically, check on those.
             return lhsFileExtensions == rhsFileExtensions && lhsHTTPMethods == rhsHTTPMethods
         }
-        
+
         return lhs.request.url!.absoluteString == rhs.request.url!.absoluteString && lhsHTTPMethods == rhsHTTPMethods
     }
 }

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -75,12 +75,12 @@ public final class MockingURLProtocol: URLProtocol {
         mock.completion?()
         mock.onCompletedExpectation?.fulfill()
     }
-    
+
     /// Implementation does nothing, but is needed for a valid inheritance of URLProtocol.
     override public func stopLoading() {
         responseWorkItem?.cancel()
     }
-    
+
     /// Simply sends back the passed request. Implementation is needed for a valid inheritance of URLProtocol.
     override public class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
@@ -98,7 +98,7 @@ private extension Data {
         let locationComponent = String(data: self, encoding: String.Encoding.utf8)?.components(separatedBy: "\n").first(where: { (value) -> Bool in
             return value.contains("Location:")
         })
-        
+
         guard let redirectLocationString = locationComponent?.components(separatedBy: "Location:").last, let redirectLocation = URL(string: redirectLocationString.trimmingCharacters(in: NSCharacterSet.whitespaces)) else {
             return nil
         }


### PR DESCRIPTION
Using specific assert functions will generate easier to understand failure messages if the tests were to fail. For example, in the `XCTAssertNil` case, it will say "something was unexpectedly not nil" instead of only "test failed".