### PR TITLE
Only link XCTest weakly for CocoaPods

### DIFF
--- a/Mocker.podspec
+++ b/Mocker.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '10.0'
   spec.source_files = 'Sources/**/*'
   spec.swift_version = '5.1'
-  spec.frameworks = 'XCTest'
+  spec.weak_framework = 'XCTest'
 end


### PR DESCRIPTION
Resolves #94

Not requiring this weakly means it'll attempt to load on every run; but XCTest will not be available when running the application directly.

## What did I do to test this?

- run `pod spec lint Mocker.podspec` to verify the podspec passes validation

```
 -> Mocker (2.5.3)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Building targets in parallel
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Analyzing workspace
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')

Analyzed 1 podspec.

Mocker.podspec passed validation.
```

- integrated the local build into a new project using

```
pod 'Mocker', :path => '~/Path/To/Mocker.podspec'
```

- verified that this does not crash at runtime
- verified that this does not crash when importing `Mocker`, and using its APIs in a test bundle
- verified that XCTest is no longer "always" required in the linked frameworks and libraries that CocoaPods generates.