### PR TITLE
Implement chained mocks feature

### DIFF
--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4DC904CC26F8B7C3002D6F9D /* ChainedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC904CB26F8B7C3002D6F9D /* ChainedMocks.swift */; };
 		501B8FC4247E89C600B885F4 /* XCTest+Mocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */; };
 		501E269E1F3DAE370048F39E /* Mocker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501E26941F3DAE370048F39E /* Mocker.framework */; };
 		503446171F3DB4660039D5E4 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503446141F3DB4660039D5E4 /* Mock.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4DC904CB26F8B7C3002D6F9D /* ChainedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainedMocks.swift; sourceTree = "<group>"; };
 		501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Mocker.swift"; sourceTree = "<group>"; };
 		501B8FC5247E8BDE00B885F4 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		501E26941F3DAE370048F39E /* Mocker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mocker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				503446141F3DB4660039D5E4 /* Mock.swift */,
+				4DC904CB26F8B7C3002D6F9D /* ChainedMocks.swift */,
 				503446151F3DB4660039D5E4 /* Mocker.swift */,
 				503446161F3DB4660039D5E4 /* MockingURLProtocol.swift */,
 				501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */,
@@ -270,6 +273,7 @@
 			files = (
 				503446191F3DB4660039D5E4 /* MockingURLProtocol.swift in Sources */,
 				501B8FC4247E89C600B885F4 /* XCTest+Mocker.swift in Sources */,
+				4DC904CC26F8B7C3002D6F9D /* ChainedMocks.swift in Sources */,
 				503446181F3DB4660039D5E4 /* Mocker.swift in Sources */,
 				503446171F3DB4660039D5E4 /* Mock.swift in Sources */,
 			);

--- a/MockerTests/MockedData.swift
+++ b/MockerTests/MockedData.swift
@@ -13,6 +13,7 @@ import UIKit
 public final class MockedData {
     public static let botAvatarImageFileUrl: URL = Bundle(for: MockedData.self).url(forResource: "wetransfer_bot_avatar", withExtension: "png")!
     public static let exampleJSON: URL = Bundle(for: MockedData.self).url(forResource: "Resources/JSON Files/example", withExtension: "json")!
+    public static let anotherExampleJSON: URL = Bundle(for: MockedData.self).url(forResource: "Resources/JSON Files/another-example", withExtension: "json")!
     public static let redirectGET: URL = Bundle(for: MockedData.self).url(forResource: "Resources/sample-redirect-get", withExtension: "data")!
 }
 

--- a/MockerTests/MockerTests.swift
+++ b/MockerTests/MockerTests.swift
@@ -383,7 +383,7 @@ final class MockerTests: XCTestCase {
     }
 
     /// It should remove all registered mocks correctly.
-    func testRemoveAll() {
+    func testRemoveAllMocks() {
         let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
         mock.register()
         Mocker.removeAll()
@@ -544,6 +544,16 @@ final class MockerTests: XCTestCase {
 
     // MARK: - ChainedMocks
 
+    /// It should remove all registered chained mocks correctly.
+    func testRemoveAllChainedMocks() {
+        Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+            .chain(Mock(dataType: .json, statusCode: 200, data: [.get: Data()]))
+            .register()
+        Mocker.removeAll()
+        XCTAssertTrue(Mocker.shared.chainedMocks.mocks.isEmpty)
+    }
+
+    // It should allow to check order for chained mocks.
     func testChainedMocksAreConsumedInOrder() {
         let firstURL = URL(string: "https://avatars3.githubusercontent.com/u/26250426?v=4&s=400")!
         let firstMock = Mock(url: firstURL, dataType: .imagePNG, statusCode: 200, data: [
@@ -566,6 +576,7 @@ final class MockerTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
+    // Chained mocks should be consumable.
     func testChainedMocksAreConsumable() {
         let firstURL = URL(string: "https://avatars3.githubusercontent.com/u/26250426?v=4&s=400")!
         let firstMock = Mock(url: firstURL, dataType: .imagePNG, statusCode: 200, data: [
@@ -606,6 +617,7 @@ final class MockerTests: XCTestCase {
         wait(for: [thirdExpectation], timeout: 1.0)
     }
 
+    // Chained mocks can be the same.
     func testChainedMocksCanBeTheSame() {
         let url = URL(string: "https://www.wetransfer.com/example.json")!
         let firstMock = Mock(url: url, dataType: .json, statusCode: 200, data: [

--- a/MockerTests/Resources/JSON Files/another-example.json
+++ b/MockerTests/Resources/JSON Files/another-example.json
@@ -1,0 +1,5 @@
+{
+    "name": "Mocker",
+    "owner": "WeTransfer",
+    "another" true
+}

--- a/Sources/ChainedMocks.swift
+++ b/Sources/ChainedMocks.swift
@@ -1,0 +1,44 @@
+//
+//  ChainedMocks.swift
+//  Mocker
+//
+//  Created by Aleksey Kuznetsov on 20.09.2021.
+//  Copyright © 2021 WeTransfer. All rights reserved.
+//
+
+import Foundation
+
+/// Chained mocks representation which can be used for mocking data requests where
+/// order is important or same requests can return different data.
+public class ChainedMocks {
+    /// The array of mocks.
+    var mocks: [Mock]
+
+    /// Creates the chained mocks.
+    ///
+    /// - Parameters:
+    ///   - mocks: The array of mocks.
+    public init(_ mocks: [Mock]) {
+        self.mocks = mocks
+    }
+
+    /// Chains another mock and returns itself.
+    public func chain(_ anotherMock: Mock) -> Self {
+        mocks.append(anotherMock)
+        return self
+    }
+
+    /// Registers the chained mocks with the `Mocker`.
+    public func register() {
+        Mocker.register(self)
+    }
+
+    /// Consumes the first element of the chained mocks and returns the next.
+    ///
+    /// Example: Suppose we have mocks [1, 2, 3], this method will return 2 and the chained mocks will become [2, 3].
+    func consume() -> Mock? {
+        guard !mocks.isEmpty else { return nil }
+        mocks.removeFirst()
+        return mocks.first
+    }
+}

--- a/Sources/ChainedMocks.swift
+++ b/Sources/ChainedMocks.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Chained mocks representation which can be used for mocking data requests where
 /// order is important or same requests can return different data.
-public class ChainedMocks {
+public final class ChainedMocks {
     /// The array of mocks.
     var mocks: [Mock]
 

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -178,6 +178,11 @@ public struct Mock: Equatable {
         Mocker.register(self)
     }
 
+    /// Chains two mocks together and returns `ChainedMocks` that can be registered with the `Mocker` by calling `register()` method.
+    public func chain(_ anotherMock: Mock) -> ChainedMocks {
+        return ChainedMocks([self, anotherMock])
+    }
+
     /// Returns `Data` based on the HTTP Method of the passed request.
     ///
     /// - Parameter request: The request to match data for.

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -134,6 +134,7 @@ public struct Mocker {
         shared.queue.sync(flags: .barrier) {
             shared.mocks.removeAll()
             shared.ignoredRules.removeAll()
+            shared.chainedMocks = ChainedMocks([])
         }
     }
 


### PR DESCRIPTION
I don't know how to call this feature. I called it `chained mocks`. Basically, we need an ability to mock the same requests but with different data after some internal event.

With this implementation you can also test the order in which requests are performed.

I believe this is a desired feature according to #98 

Please let me know what you think. I'm happy to update the readme to reflect this feature if you're ready to accept the PR.