### PR TITLE
Merge release 2.5.5 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### 2.5.5
+- Allow subclassing the MockingURLProtocol, fallback for HTTP Body ([#109](https://github.com/WeTransfer/Mocker/pull/109)) via [@AvdLee](https://github.com/AvdLee)
+
 ### 2.5.4
 - Improve test expressivity ([#101](https://github.com/WeTransfer/Mocker/pull/101)) via [@BasThomas](https://github.com/BasThomas)
 - Installation via CocoaPods is Broken ([#94](https://github.com/WeTransfer/Mocker/issues/94)) via [@BasThomas](https://github.com/BasThomas)

--- a/Mocker.podspec
+++ b/Mocker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Mocker'
-  spec.version          = '2.5.4'
+  spec.version          = '2.5.5'
   spec.summary          = 'Mock data requests using a custom URLProtocol and run them offline.'
   spec.description      = 'Mocker is a library written in Swift which makes it possible to mock data requests using a custom URLProtocol and run them offline.'
 


### PR DESCRIPTION
Containing all the changes for our [**2.5.5 Release**](https://github.com/WeTransfer/Mocker/releases/tag/2.5.5).