### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ URLSession.shared.dataTask(with: exampleURL) { (data, response, error) in
 ```
 
 ##### Delayed responses
-Sometimes you want to test if cancellation of requests is working. In that case, the mocked request should not finished directly and you need an delay. This can be added easily:
+Sometimes you want to test if cancellation of requests is working. In that case, the mocked request should not finish immediately and you need an delay. This can be added easily:
 
 ```swift
 let exampleURL = URL(string: "https://www.wetransfer.com/api/endpoint")!


### PR DESCRIPTION
Clarify delayed response condition. Sounds more natural to my American English ear to say "finish immediately" instead of "finished directly."