### PR TITLE
Linux support

### DIFF
--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -10,6 +10,9 @@
 
 import Foundation
 import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// A Mock which can be used for mocking data requests with the `Mocker` by calling `Mocker.register(...)`.
 public struct Mock: Equatable {

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -76,7 +76,7 @@ public struct Mocker {
 
     private init() {
         // Whenever someone is requesting the Mocker, we want the URL protocol to be activated.
-        URLProtocol.registerClass(MockingURLProtocol.self)
+        _ = URLProtocol.registerClass(MockingURLProtocol.self)
     }
 
     /// Register new Mocked data. If a mock for the same URL and HTTPMethod exists, it will be overwritten.

--- a/Sources/Mocker.swift
+++ b/Sources/Mocker.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Can be used for registering Mocked data, returned by the `MockingURLProtocol`.
 public struct Mocker {

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// The protocol which can be used to send Mocked data back. Use the `Mocker` to register `Mock` data
 open class MockingURLProtocol: URLProtocol {


### PR DESCRIPTION
These extra imports allow to use the library in tests on Linux. As an example I've enabled Linux tests in [kean/Get](https://github.com/vox-humana/Get/commit/4f5fb61bfd16dd1e77a2399e29f693d4dd6af00a) library.

Also, removed unrelated warning that `swift build` showed:
```
Mocker.swift:79:21: warning: result of call to 'registerClass' is unused
        URLProtocol.registerClass(MockingURLProtocol.self)
                    ^            ~~~~~~~~~~~~~~~~~~~~~~~~~
```