### PR TITLE
Merge release 2.5.6 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### 2.5.6
+- Linux support ([#116](https://github.com/WeTransfer/Mocker/pull/116)) via [@vox-humana](https://github.com/vox-humana)
+- Adds Raphael as a code owner ([#114](https://github.com/WeTransfer/Mocker/pull/114)) via [@kairadiagne](https://github.com/kairadiagne)
+- Update README.md ([#113](https://github.com/WeTransfer/Mocker/pull/113)) via [@hawflakes](https://github.com/hawflakes)
+- Update README.md ([#112](https://github.com/WeTransfer/Mocker/pull/112)) via [@amdprophet](https://github.com/amdprophet)
+- Merge release 2.5.5 into master ([#111](https://github.com/WeTransfer/Mocker/pull/111)) via [@wetransferplatform](https://github.com/wetransferplatform)
+
 ### 2.5.5
 - Allow subclassing the MockingURLProtocol, fallback for HTTP Body ([#109](https://github.com/WeTransfer/Mocker/pull/109)) via [@AvdLee](https://github.com/AvdLee)
 

--- a/Mocker.podspec
+++ b/Mocker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Mocker'
-  spec.version          = '2.5.5'
+  spec.version          = '2.5.6'
   spec.summary          = 'Mock data requests using a custom URLProtocol and run them offline.'
   spec.description      = 'Mocker is a library written in Swift which makes it possible to mock data requests using a custom URLProtocol and run them offline.'
 


### PR DESCRIPTION
Containing all the changes for our [**2.5.6 Release**](https://github.com/WeTransfer/Mocker/releases/tag/2.5.6).