### PR TITLE
Enable swift PM tests on Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: "Mocker SPM CI"
+
+on: 
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - '*'
+
+jobs:
+  macos-run-tests:
+    name: Unit Tests (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        run: swift test
+
+  linux-run-tests:
+    name: Unit Tests (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        run: swift test

--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -15,7 +15,9 @@
 		50D4606E20653F1F00A85D93 /* Mocker.h in Headers */ = {isa = PBXBuildFile; fileRef = 50D4606B20653F1F00A85D93 /* Mocker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		50D4607020653F2500A85D93 /* MockedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D4605B20653EAF00A85D93 /* MockedData.swift */; };
 		50D4607120653F2700A85D93 /* MockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D4605C20653EAF00A85D93 /* MockerTests.swift */; };
-		50D4607320653F4500A85D93 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 50D4607220653F4500A85D93 /* Resources */; };
+		8ED91F36283AFDC300EA8E99 /* wetransfer_bot_avatar.png in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F32283AFDC300EA8E99 /* wetransfer_bot_avatar.png */; };
+		8ED91F37283AFDC300EA8E99 /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F34283AFDC300EA8E99 /* example.json */; };
+		8ED91F38283AFDC300EA8E99 /* sample-redirect-get.data in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F35283AFDC300EA8E99 /* sample-redirect-get.data */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,7 +45,9 @@
 		50D4606320653EAF00A85D93 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50D4606B20653F1F00A85D93 /* Mocker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Mocker.h; sourceTree = "<group>"; };
 		50D4606D20653F1F00A85D93 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		50D4607220653F4500A85D93 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
+		8ED91F32283AFDC300EA8E99 /* wetransfer_bot_avatar.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wetransfer_bot_avatar.png; sourceTree = "<group>"; };
+		8ED91F34283AFDC300EA8E99 /* example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = example.json; sourceTree = "<group>"; };
+		8ED91F35283AFDC300EA8E99 /* sample-redirect-get.data */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sample-redirect-get.data"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,9 +105,9 @@
 		50D4605A20653EAF00A85D93 /* MockerTests */ = {
 			isa = PBXGroup;
 			children = (
+				8ED91F31283AFDC300EA8E99 /* Resources */,
 				50D4605B20653EAF00A85D93 /* MockedData.swift */,
 				50D4605C20653EAF00A85D93 /* MockerTests.swift */,
-				50D4607220653F4500A85D93 /* Resources */,
 				50D4606220653EAF00A85D93 /* Supporting Files */,
 			);
 			path = MockerTests;
@@ -132,6 +136,24 @@
 				50D4606D20653F1F00A85D93 /* Info.plist */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		8ED91F31283AFDC300EA8E99 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				8ED91F32283AFDC300EA8E99 /* wetransfer_bot_avatar.png */,
+				8ED91F33283AFDC300EA8E99 /* JSON Files */,
+				8ED91F35283AFDC300EA8E99 /* sample-redirect-get.data */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		8ED91F33283AFDC300EA8E99 /* JSON Files */ = {
+			isa = PBXGroup;
+			children = (
+				8ED91F34283AFDC300EA8E99 /* example.json */,
+			);
+			path = "JSON Files";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -240,7 +262,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				50D4607320653F4500A85D93 /* Resources in Resources */,
+				8ED91F36283AFDC300EA8E99 /* wetransfer_bot_avatar.png in Resources */,
+				8ED91F38283AFDC300EA8E99 /* sample-redirect-get.data in Resources */,
+				8ED91F37283AFDC300EA8E99 /* example.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -152,9 +152,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 501E26A81F3DAE370048F39E /* Build configuration list for PBXNativeTarget "Mocker" */;
 			buildPhases = (
+				501E26911F3DAE370048F39E /* Headers */,
 				501E268F1F3DAE370048F39E /* Sources */,
 				501E26901F3DAE370048F39E /* Frameworks */,
-				501E26911F3DAE370048F39E /* Headers */,
 				501E26921F3DAE370048F39E /* Resources */,
 				503446441F3DE70C0039D5E4 /* SwiftLint */,
 			);

--- a/MockerTests/MockedData.swift
+++ b/MockerTests/MockedData.swift
@@ -7,13 +7,18 @@
 //
 
 import Foundation
-import UIKit
 
 /// Contains all available Mocked data.
 public final class MockedData {
-    public static let botAvatarImageFileUrl: URL = Bundle(for: MockedData.self).url(forResource: "wetransfer_bot_avatar", withExtension: "png")!
-    public static let exampleJSON: URL = Bundle(for: MockedData.self).url(forResource: "Resources/JSON Files/example", withExtension: "json")!
-    public static let redirectGET: URL = Bundle(for: MockedData.self).url(forResource: "Resources/sample-redirect-get", withExtension: "data")!
+    public static let botAvatarImageFileUrl: URL = Bundle.module.url(forResource: "wetransfer_bot_avatar", withExtension: "png")!
+    public static let exampleJSON: URL = Bundle.module.url(forResource: "example", withExtension: "json")!
+    public static let redirectGET: URL = Bundle.module.url(forResource: "sample-redirect-get", withExtension: "data")!
+}
+
+extension Bundle {
+#if !SWIFT_PACKAGE
+    static let module = Bundle(for: MockedData.self)
+#endif
 }
 
 internal extension URL {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,6 @@ let package = Package(name: "Mocker",
                         // dev     .product(name: "WeTransferPRLinter", package: "WeTransferPRLinter")
                         // dev ], path: "Submodules/WeTransfer-iOS-CI/DangerFakeSources", sources: ["DangerFakeSource.swift"]),
                         .target(name: "Mocker", path: "Sources"),
-                        .testTarget(name: "MockerTests", dependencies: ["Mocker"], path: "MockerTests")
+                        .testTarget(name: "MockerTests", dependencies: ["Mocker"], path: "MockerTests", resources: [.process("Resources")])
                         ],
                       swiftLanguageVersions: [.v5])


### PR DESCRIPTION
Follow up from #116 
- Removed `UIKit.UIImage` dependency from tests.
- Added a simple GitHub action that runs `swift test` on Linux and macOS. Not sure whether it should be integrated in https://github.com/WeTransfer/WeTransfer-iOS-CI.
- Changed the order of build steps in test target as Xcode build was failing with:
> error: Cycle inside Mocker; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.
- Had to change integration of resource files in the test target as copying them on Linux cases [this crash](https://github.com/apple/swift/issues/56730).
- Two tests (testMockCachePolicy and testRedirectResponse) were disabled on Linux as seems that swift-corelibs-foundation doesn't support these features.
