### PR TITLE
Add option to create a custom data type

### DIFF
--- a/Mocker.xcodeproj/project.pbxproj
+++ b/Mocker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		8ED91F36283AFDC300EA8E99 /* wetransfer_bot_avatar.png in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F32283AFDC300EA8E99 /* wetransfer_bot_avatar.png */; };
 		8ED91F37283AFDC300EA8E99 /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F34283AFDC300EA8E99 /* example.json */; };
 		8ED91F38283AFDC300EA8E99 /* sample-redirect-get.data in Resources */ = {isa = PBXBuildFile; fileRef = 8ED91F35283AFDC300EA8E99 /* sample-redirect-get.data */; };
+		A4B51386288FD81B00C52F4A /* Mock+DataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B51385288FD81B00C52F4A /* Mock+DataType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +49,7 @@
 		8ED91F32283AFDC300EA8E99 /* wetransfer_bot_avatar.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wetransfer_bot_avatar.png; sourceTree = "<group>"; };
 		8ED91F34283AFDC300EA8E99 /* example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = example.json; sourceTree = "<group>"; };
 		8ED91F35283AFDC300EA8E99 /* sample-redirect-get.data */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sample-redirect-get.data"; sourceTree = "<group>"; };
+		A4B51385288FD81B00C52F4A /* Mock+DataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mock+DataType.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +100,7 @@
 				503446151F3DB4660039D5E4 /* Mocker.swift */,
 				503446161F3DB4660039D5E4 /* MockingURLProtocol.swift */,
 				501B8FC3247E89C600B885F4 /* XCTest+Mocker.swift */,
+				A4B51385288FD81B00C52F4A /* Mock+DataType.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 			files = (
 				503446191F3DB4660039D5E4 /* MockingURLProtocol.swift in Sources */,
 				501B8FC4247E89C600B885F4 /* XCTest+Mocker.swift in Sources */,
+				A4B51386288FD81B00C52F4A /* Mock+DataType.swift in Sources */,
 				503446181F3DB4660039D5E4 /* Mocker.swift in Sources */,
 				503446171F3DB4660039D5E4 /* Mock.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ URLSession.shared.dataTask(with: exampleURL) { (data, response, error) in
 }.resume()
 ```
 
+##### Custom DataType
+In addition to the already build in static `DataType` implementations it is possible to create custom ones which will be used as the value to the `Content-Type` header key. 
+
+```swift
+let xmlURL = URL(string: "https://www.wetransfer.com/sample-xml.xml")!
+
+Mock(fileExtensions: "png", dataType: .init(name: "xml", headerValue: "text/xml"), statusCode: 200, data: [
+    .get: try! Data(contentsOf: MockedData.sampleXML)
+]).register()
+
+URLSession.shared.dataTask(with: xmlURL) { (data, response, error) in
+    let sampleXML: Data = data // This is the xml from your resources.
+}.resume(
+```
+
+
 ##### Delayed responses
 Sometimes you want to test if cancellation of requests is working. In that case, the mocked request should not finish immediately and you need an delay. This can be added easily:
 

--- a/Sources/Mock+DataType.swift
+++ b/Sources/Mock+DataType.swift
@@ -1,0 +1,36 @@
+//
+//  Mock+DataType.swift
+//  Mocker
+//
+//  Created by Weiß, Alexander on 26.07.22.
+//  Copyright © 2022 WeTransfer. All rights reserved.
+//
+
+import Foundation
+
+extension Mock {
+    /// The types of content of a request. Will be used as Content-Type header inside a `Mock`.
+    public struct DataType {
+
+        /// Name of the data type
+        public let name: String
+
+
+        /// The header value of the data type
+        public let headerValue: String
+
+        public init(name: String, headerValue: String) {
+            self.name = name
+            self.headerValue = headerValue
+        }
+    }
+}
+
+extension Mock.DataType {
+    public static var json = Mock.DataType(name: "json", headerValue: "application/json; charset=utf-8")
+    public static var html = Mock.DataType(name: "html", headerValue: "text/html; charset=utf-8")
+    public static var imagePNG = Mock.DataType(name: "imagePNG",headerValue: "image/png")
+    public static var pdf = Mock.DataType(name: "pdf",headerValue: "application/pdf")
+    public static var mp4 = Mock.DataType(name: "mp4",headerValue: "video/mp4")
+    public static var zip = Mock.DataType(name: "zip",headerValue: "application/zip")
+}

--- a/Sources/Mock+DataType.swift
+++ b/Sources/Mock+DataType.swift
@@ -12,11 +12,10 @@ extension Mock {
     /// The types of content of a request. Will be used as Content-Type header inside a `Mock`.
     public struct DataType {
 
-        /// Name of the data type
+        /// Name of the data type.
         public let name: String
 
-
-        /// The header value of the data type
+        /// The header value of the data type.
         public let headerValue: String
 
         public init(name: String, headerValue: String) {
@@ -27,10 +26,10 @@ extension Mock {
 }
 
 extension Mock.DataType {
-    public static var json = Mock.DataType(name: "json", headerValue: "application/json; charset=utf-8")
-    public static var html = Mock.DataType(name: "html", headerValue: "text/html; charset=utf-8")
-    public static var imagePNG = Mock.DataType(name: "imagePNG",headerValue: "image/png")
-    public static var pdf = Mock.DataType(name: "pdf",headerValue: "application/pdf")
-    public static var mp4 = Mock.DataType(name: "mp4",headerValue: "video/mp4")
-    public static var zip = Mock.DataType(name: "zip",headerValue: "application/zip")
+    public static let json = Mock.DataType(name: "json", headerValue: "application/json; charset=utf-8")
+    public static let html = Mock.DataType(name: "html", headerValue: "text/html; charset=utf-8")
+    public static let imagePNG = Mock.DataType(name: "imagePNG", headerValue: "image/png")
+    public static let pdf = Mock.DataType(name: "pdf", headerValue: "application/pdf")
+    public static let mp4 = Mock.DataType(name: "mp4", headerValue: "video/mp4")
+    public static let zip = Mock.DataType(name: "zip", headerValue: "application/zip")
 }

--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -32,33 +32,6 @@ public struct Mock: Equatable {
         case connect = "CONNECT"
     }
 
-    /// The types of content of a request. Will be used as Content-Type header inside a `Mock`.
-    public enum DataType: String {
-        case json
-        case html
-        case imagePNG
-        case pdf
-        case mp4
-        case zip
-
-        var headerValue: String {
-            switch self {
-            case .json:
-                return "application/json; charset=utf-8"
-            case .html:
-                return "text/html; charset=utf-8"
-            case .imagePNG:
-                return "image/png"
-            case .pdf:
-                return "application/pdf"
-            case .mp4:
-                return "video/mp4"
-            case .zip:
-                return "application/zip"
-            }
-        }
-    }
-
     public typealias OnRequest = (_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> Void
 
     /// The type of the data which is returned.
@@ -119,7 +92,7 @@ public struct Mock: Equatable {
 
     private init(url: URL? = nil, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], requestError: Error? = nil, additionalHeaders: [String: String] = [:], fileExtensions: [String]? = nil) {
         self.urlToMock = url
-        let generatedURL = URL(string: "https://mocked.wetransfer.com/\(dataType.rawValue)/\(statusCode)/\(data.keys.first!.rawValue)")!
+        let generatedURL = URL(string: "https://mocked.wetransfer.com/\(dataType.name)/\(statusCode)/\(data.keys.first!.rawValue)")!
         self.generatedURL = generatedURL
         var request = URLRequest(url: url ?? generatedURL)
         request.httpMethod = data.keys.first!.rawValue


### PR DESCRIPTION
Hey all, 

at first thanks a lot for this great library! I saw that it is not possible to easily extend `Mock.DataType` with custom ones. Therefore I try to solve this issue with this PR. I changed the type from `enum` to `struct` to give consumers the ability to create new instances of `DataType`. 

Furthermore I already created static variables on the `DataType` to not break any existing code with the types that were previously already in the library. 

I needed this particular feature, because I also want to test my network responses if they return a specific kind of content type. 

I would very appreciate if you could have a look into this :) Also happy for any feedback here !