### PR TITLE
Merge release 2.6.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 2.6.0
+- Add option to create a custom data type ([#121](https://github.com/WeTransfer/Mocker/pull/121)) via [@alexanderwe](https://github.com/alexanderwe)
+- Enable swift PM tests on Linux and macOS ([#118](https://github.com/WeTransfer/Mocker/pull/118)) via [@vox-humana](https://github.com/vox-humana)
+- Merge release 2.5.6 into master ([#117](https://github.com/WeTransfer/Mocker/pull/117)) via [@wetransferplatform](https://github.com/wetransferplatform)
+
 ### 2.5.6
 - Linux support ([#116](https://github.com/WeTransfer/Mocker/pull/116)) via [@vox-humana](https://github.com/vox-humana)
 - Adds Raphael as a code owner ([#114](https://github.com/WeTransfer/Mocker/pull/114)) via [@kairadiagne](https://github.com/kairadiagne)

--- a/Mocker.podspec
+++ b/Mocker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Mocker'
-  spec.version          = '2.5.6'
+  spec.version          = '2.6.0'
   spec.summary          = 'Mock data requests using a custom URLProtocol and run them offline.'
   spec.description      = 'Mocker is a library written in Swift which makes it possible to mock data requests using a custom URLProtocol and run them offline.'
 


### PR DESCRIPTION
Containing all the changes for our [**2.6.0 Release**](https://github.com/WeTransfer/Mocker/releases/tag/2.6.0).