### PR TITLE
Support collection types as a top level object

### DIFF
--- a/Sources/Mock.swift
+++ b/Sources/Mock.swift
@@ -32,7 +32,7 @@ public struct Mock: Equatable {
         case connect = "CONNECT"
     }
 
-    public typealias OnRequest = (_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> Void
+    public typealias OnRequest = (_ request: URLRequest, _ httpBodyArguments: Any?) -> Void
 
     /// The type of the data which is returned.
     public let dataType: DataType

--- a/Sources/MockingURLProtocol.swift
+++ b/Sources/MockingURLProtocol.swift
@@ -110,9 +110,9 @@ private extension Data {
 }
 
 private extension URLRequest {
-    var postBodyArguments: [String: Any]? {
+    var postBodyArguments: Any? {
         guard let httpBody = httpBodyStreamData() ?? httpBody else { return nil }
-        return try? JSONSerialization.jsonObject(with: httpBody, options: .fragmentsAllowed) as? [String: Any]
+        return try? JSONSerialization.jsonObject(with: httpBody, options: .fragmentsAllowed)
     }
 
     /// We need to use the http body stream data as the URLRequest once launched converts the `httpBody` to this stream of data.


### PR DESCRIPTION
As you know, top level collection objects are also valid JSON. But, Mocker wasn't support them because of the casting that made up in the `MockingURLProtocol.swift`