### PR TITLE
Add extra capabilities for on request handling

### DIFF
--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -85,7 +85,7 @@ public struct Mock: Equatable {
     @available(*, deprecated, message: "Use `onRequestHandler` instead.")
     public var onRequest: OnRequest? {
         set {
-            onRequestHandler = OnRequestHandler(callback: newValue)
+            onRequestHandler = OnRequestHandler(legacyCallback: newValue)
         }
         get {
             onRequestHandler?.legacyCallback

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,11 +6,6 @@ import "./../Submodules/WeTransfer-iOS-CI/Fastlane/shared_lanes.rb"
 
 desc "Run the tests and prepare for Danger"
 lane :test do |options|
-
-  # Remove any leftover reports before running so CI won't fail due to an existing file.
-  # This also helps for local running this workflow frequently.
-  sh("rm -rf #{ENV['PWD']}/build/reports")
-  
   test_package(
     package_name: 'Mocker',
     package_path: ENV['PWD'],


### PR DESCRIPTION
During updating our internal projects to the latest major release of Mocker it turned out that the on-request handler could be improved with a few common scenarios. We now offer callbacks for:
- Empty on request handlers, no interest in request or body arguments
- Top-level collection body arguments
- JSON Dictionary body arguments
- Decodable body arguments
- URLRequest-only containing callback

I'm convinced this will level up the possibilities our framework offers to all our users.
Secondly, we didn't test all scenarios, so I added a few more to increase coverage.