### PR TITLE
Optional dataType

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ public final class MockedData {
 ``` swift
 let originalURL = URL(string: "https://www.wetransfer.com/example.json")!
     
-let mock = Mock(url: originalURL, dataType: .json, statusCode: 200, data: [
+let mock = Mock(url: originalURL, contentType: .json, statusCode: 200, data: [
     .get : try! Data(contentsOf: MockedData.exampleJSON) // Data containing the JSON response
 ])
 mock.register()
@@ -123,7 +123,7 @@ Some URLs like authentication URLs contain timestamps or UUIDs in the query. To 
 /// Would transform to "https://www.example.com/api/authentication" for example.
 let originalURL = URL(string: "https://www.example.com/api/authentication?oauth_timestamp=151817037")!
     
-let mock = Mock(url: originalURL, ignoreQuery: true, dataType: .json, statusCode: 200, data: [
+let mock = Mock(url: originalURL, ignoreQuery: true, contentType: .json, statusCode: 200, data: [
     .get : try! Data(contentsOf: MockedData.exampleJSON) // Data containing the JSON response
 ])
 mock.register()
@@ -143,7 +143,7 @@ URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
 ```swift
 let imageURL = URL(string: "https://www.wetransfer.com/sample-image.png")!
 
-Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [
+Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 200, data: [
     .get: try! Data(contentsOf: MockedData.botAvatarImageFileUrl)
 ]).register()
 
@@ -156,7 +156,7 @@ URLSession.shared.dataTask(with: imageURL) { (data, response, error) in
 ```swift
 let exampleURL = URL(string: "https://www.wetransfer.com/api/endpoint")!
 
-Mock(url: exampleURL, dataType: .json, statusCode: 200, data: [
+Mock(url: exampleURL, contentType: .json, statusCode: 200, data: [
     .head: try! Data(contentsOf: MockedData.headResponse),
     .get: try! Data(contentsOf: MockedData.exampleJSON)
 ]).register()
@@ -172,7 +172,7 @@ In addition to the already build in static `DataType` implementations it is poss
 ```swift
 let xmlURL = URL(string: "https://www.wetransfer.com/sample-xml.xml")!
 
-Mock(fileExtensions: "png", dataType: .init(name: "xml", headerValue: "text/xml"), statusCode: 200, data: [
+Mock(fileExtensions: "png", contentType: .init(name: "xml", headerValue: "text/xml"), statusCode: 200, data: [
     .get: try! Data(contentsOf: MockedData.sampleXML)
 ]).register()
 
@@ -188,7 +188,7 @@ Sometimes you want to test if the cancellation of requests is working. In that c
 ```swift
 let exampleURL = URL(string: "https://www.wetransfer.com/api/endpoint")!
 
-var mock = Mock(url: exampleURL, dataType: .json, statusCode: 200, data: [
+var mock = Mock(url: exampleURL, contentType: .json, statusCode: 200, data: [
     .head: try! Data(contentsOf: MockedData.headResponse),
     .get: try! Data(contentsOf: MockedData.exampleJSON)
 ])
@@ -208,8 +208,8 @@ By creating a mock for the short URL and the redirect URL, you can mock redirect
 
 ```swift
 let urlWhichRedirects: URL = URL(string: "https://we.tl/redirect")!
-Mock(url: urlWhichRedirects, dataType: .html, statusCode: 200, data: [.get: try! Data(contentsOf: MockedData.redirectGET)]).register()
-Mock(url: URL(string: "https://wetransfer.com/redirect")!, dataType: .json, statusCode: 200, data: [.get: try! Data(contentsOf: MockedData.exampleJSON)]).register()
+Mock(url: urlWhichRedirects, contentType: .html, statusCode: 200, data: [.get: try! Data(contentsOf: MockedData.redirectGET)]).register()
+Mock(url: URL(string: "https://wetransfer.com/redirect")!, contentType: .json, statusCode: 200, data: [.get: try! Data(contentsOf: MockedData.exampleJSON)]).register()
 ```
 
 ##### Ignoring URLs
@@ -237,7 +237,7 @@ Mocker.mode = .optout
 You can request a `Mock` to return an error, allowing testing of error handling.
 
 ```swift
-Mock(url: originalURL, dataType: .json, statusCode: 500, data: [.get: Data()],
+Mock(url: originalURL, contentType: .json, statusCode: 500, data: [.get: Data()],
      requestError: TestExampleError.example).register()
 
 URLSession.shared.dataTask(with: originalURL) { (data, urlresponse, err) in
@@ -259,7 +259,7 @@ URLSession.shared.dataTask(with: originalURL) { (data, urlresponse, err) in
 You can register on `Mock` callbacks to make testing easier.
 
 ```swift
-var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
 mock.onRequestHandler = OnRequestHandler(httpBodyType: [[String:String]].self, callback: { request, postBodyArguments in
     XCTAssertEqual(request.url, mock.request.url)
     XCTAssertEqual(expectedParameters, postBodyArguments)
@@ -275,7 +275,7 @@ mock.register()
 Instead of setting the `completion` and `onRequest` you can also make use of expectations:
 
 ```swift
-var mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
+var mock = Mock(url: url, contentType: .json, statusCode: 200, data: [.get: Data()])
 let requestExpectation = expectationForRequestingMock(&mock)
 let completionExpectation = expectationForCompletingMock(&mock)
 mock.register()

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
 }.resume()
 ```
 
+##### Empty Responses
+``` swift
+let originalURL = URL(string: "https://www.wetransfer.com/api/foobar")!
+var request = URLRequest(url: originalURL)
+request.httpMethod = "PUT"
+    
+let mock = Mock(url: originalURL, statusCode: 204, data: [
+    .put : Data()
+])
+mock.register()
+
+URLSession.shared.dataTask(with: originalURL) { (data, response, error) in
+    // ....
+}.resume()
+```
+
 ##### Ignoring the query
 Some URLs like authentication URLs contain timestamps or UUIDs in the query. To mock these you can ignore the Query for a certain URL:
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ let originalURL = URL(string: "https://www.wetransfer.com/api/foobar")!
 var request = URLRequest(url: originalURL)
 request.httpMethod = "PUT"
     
-let mock = Mock(url: originalURL, statusCode: 204, data: [
-    .put : Data()
-])
+let mock = Mock(request: request, statusCode: 204)
 mock.register()
 
 URLSession.shared.dataTask(with: originalURL) { (data, response, error) in

--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -34,8 +34,8 @@ public struct Mock: Equatable {
 
     public typealias OnRequest = (_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> Void
 
-    /// The type of the data which is returned.
-    public let dataType: DataType
+    /// The type of the data which designates the Content-Type header. If set to `nil`, no Content-Type header is added to the headers.
+    public let dataType: DataType?
 
     /// If set, the error that URLProtocol will report as a result rather than returning data from the mock
     public let requestError: Error?
@@ -101,9 +101,9 @@ public struct Mock: Equatable {
     /// Can only be set internally as it's used by the `expectationForCompletingMock(_:)` method.
     var onCompletedExpectation: XCTestExpectation?
 
-    private init(url: URL? = nil, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], requestError: Error? = nil, additionalHeaders: [String: String] = [:], fileExtensions: [String]? = nil) {
+    private init(url: URL? = nil, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType? = nil, statusCode: Int, data: [HTTPMethod: Data], requestError: Error? = nil, additionalHeaders: [String: String] = [:], fileExtensions: [String]? = nil) {
         self.urlToMock = url
-        let generatedURL = URL(string: "https://mocked.wetransfer.com/\(dataType.name)/\(statusCode)/\(data.keys.first!.rawValue)")!
+        let generatedURL = URL(string: "https://mocked.wetransfer.com/\(dataType?.name ?? "no-content")/\(statusCode)/\(data.keys.first!.rawValue)")!
         self.generatedURL = generatedURL
         var request = URLRequest(url: url ?? generatedURL)
         request.httpMethod = data.keys.first!.rawValue
@@ -116,7 +116,9 @@ public struct Mock: Equatable {
         self.cacheStoragePolicy = cacheStoragePolicy
 
         var headers = additionalHeaders
-        headers["Content-Type"] = dataType.headerValue
+        if let dataType = dataType {
+            headers["Content-Type"] = dataType.headerValue
+        }
         self.headers = headers
 
         self.fileExtensions = fileExtensions?.map({ $0.replacingOccurrences(of: ".", with: "") })
@@ -125,11 +127,11 @@ public struct Mock: Equatable {
     /// Creates a `Mock` for the given data type. The mock will be automatically matched based on a URL created from the given parameters.
     ///
     /// - Parameters:
-    ///   - dataType: The type of the data which is returned.
+    ///   - dataType: The type of the data which designates the Content-Type header. Defaults to `nil`, which means that no Content-Type header is added to the headers.
     ///   - statusCode: The HTTP status code to return with the response.
     ///   - data: The data which will be returned as the response based on the HTTP Method.
     ///   - additionalHeaders: Additional headers to be added to the response.
-    public init(dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
+    public init(dataType: DataType? = nil, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
         self.init(url: nil, dataType: dataType, statusCode: statusCode, data: data, additionalHeaders: additionalHeaders, fileExtensions: nil)
     }
 
@@ -140,11 +142,11 @@ public struct Mock: Equatable {
     ///   - ignoreQuery: If `true`, checking the URL will ignore the query and match only for the scheme, host and path. Defaults to `false`.
     ///   - cacheStoragePolicy: The caching strategy. Defaults to `notAllowed`.
     ///   - reportFailure: if `true`, the URLsession will report an error loading the URL rather than returning data. Defaults to `false`.
-    ///   - dataType: The type of the data which is returned.
+    ///   - dataType: The type of the data which designates the Content-Type header. Defaults to `nil`, which means that no Content-Type header is added to the headers.
     ///   - statusCode: The HTTP status code to return with the response.
     ///   - data: The data which will be returned as the response based on the HTTP Method.
     ///   - additionalHeaders: Additional headers to be added to the response.
-    public init(url: URL, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:], requestError: Error? = nil) {
+    public init(url: URL, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, dataType: DataType? = nil, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:], requestError: Error? = nil) {
         self.init(url: url, ignoreQuery: ignoreQuery, cacheStoragePolicy: cacheStoragePolicy, dataType: dataType, statusCode: statusCode, data: data, requestError: requestError, additionalHeaders: additionalHeaders, fileExtensions: nil)
     }
 
@@ -152,11 +154,11 @@ public struct Mock: Equatable {
     ///
     /// - Parameters:
     ///   - fileExtensions: The file extension to match for.
-    ///   - dataType: The type of the data which is returned.
+    ///   - dataType: The type of the data which designates the Content-Type header. Defaults to `nil`, which means that no Content-Type header is added to the headers.
     ///   - statusCode: The HTTP status code to return with the response.
     ///   - data: The data which will be returned as the response based on the HTTP Method.
     ///   - additionalHeaders: Additional headers to be added to the response.
-    public init(fileExtensions: String..., dataType: DataType, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
+    public init(fileExtensions: String..., dataType: DataType? = nil, statusCode: Int, data: [HTTPMethod: Data], additionalHeaders: [String: String] = [:]) {
         self.init(url: nil, dataType: dataType, statusCode: statusCode, data: data, additionalHeaders: additionalHeaders, fileExtensions: fileExtensions)
     }
 

--- a/Tests/MockerTests/MockTests.swift
+++ b/Tests/MockerTests/MockTests.swift
@@ -23,10 +23,10 @@ final class MockTests: XCTestCase {
 
     /// It should match two file extension mocks correctly.
     func testFileExtensionMocksComparing() {
-        let mock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
-        let secondMock200 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
-        let mock400 = Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 400, data: [.put: Data()])
-        let mockJPEG = Mock(fileExtensions: "jpeg", dataType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        let mock200 = Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        let secondMock200 = Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 200, data: [.put: Data()])
+        let mock400 = Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 400, data: [.put: Data()])
+        let mockJPEG = Mock(fileExtensions: "jpeg", contentType: .imagePNG, statusCode: 200, data: [.put: Data()])
 
         XCTAssertEqual(mock200, secondMock200)
         XCTAssertEqual(mock200, mock400)

--- a/Tests/MockerTests/MockerTests.swift
+++ b/Tests/MockerTests/MockerTests.swift
@@ -40,7 +40,7 @@ final class MockerTests: XCTestCase {
         let originalURL = URL(string: "https://avatars3.githubusercontent.com/u/26250426?v=4&s=400")!
 
         let mockedData = MockedData.botAvatarImageFileUrl.data
-        let mock = Mock(url: originalURL, dataType: .imagePNG, statusCode: 200, data: [
+        let mock = Mock(url: originalURL, contentType: .imagePNG, statusCode: 200, data: [
             .get: mockedData
         ])
 
@@ -60,7 +60,7 @@ final class MockerTests: XCTestCase {
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png")
 
         let mockedData = MockedData.botAvatarImageFileUrl.data
-        Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [
+        Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 200, data: [
             .get: mockedData
         ]).register()
 
@@ -78,12 +78,12 @@ final class MockerTests: XCTestCase {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png")!
 
-        Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 400, data: [
+        Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 400, data: [
             .get: Data()
         ]).register()
 
         let mockedData = MockedData.botAvatarImageFileUrl.data
-        Mock(url: originalURL, ignoreQuery: true, dataType: .imagePNG, statusCode: 200, data: [
+        Mock(url: originalURL, ignoreQuery: true, contentType: .imagePNG, statusCode: 200, data: [
             .get: mockedData
         ]).register()
 
@@ -102,7 +102,7 @@ final class MockerTests: XCTestCase {
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
 
         let mockedData = MockedData.botAvatarImageFileUrl.data
-        Mock(url: originalURL, ignoreQuery: true, dataType: .imagePNG, statusCode: 200, data: [
+        Mock(url: originalURL, ignoreQuery: true, contentType: .imagePNG, statusCode: 200, data: [
             .get: mockedData
         ]).register()
 
@@ -123,7 +123,7 @@ final class MockerTests: XCTestCase {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/example.json")!
 
-        Mock(url: originalURL, dataType: .json, statusCode: 200, data: [
+        Mock(url: originalURL, contentType: .json, statusCode: 200, data: [
             .get: MockedData.exampleJSON.data
         ]).register()
 
@@ -179,7 +179,7 @@ final class MockerTests: XCTestCase {
     func testAdditionalHeaders() {
         let expectation = self.expectation(description: "Data request should succeed")
         let headers = ["Testkey": "testvalue"]
-        let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: headers)
+        let mock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: headers)
         mock.register()
 
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
@@ -194,10 +194,10 @@ final class MockerTests: XCTestCase {
     /// It should override existing mocks.
     func testMockOverriding() {
         let expectation = self.expectation(description: "Data request should succeed")
-        let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["testkey": "testvalue"])
+        let mock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["testkey": "testvalue"])
         mock.register()
 
-        let newMock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["Newkey": "newvalue"])
+        let newMock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()], additionalHeaders: ["Newkey": "newvalue"])
         newMock.register()
 
         URLSession.shared.dataTask(with: mock.request) { (_, response, error) in
@@ -215,7 +215,7 @@ final class MockerTests: XCTestCase {
         let originalURL = URL(string: "https://www.wetransfer.com/sample-image.png")
 
         let mockedData = MockedData.botAvatarImageFileUrl.data
-        Mock(fileExtensions: "png", dataType: .imagePNG, statusCode: 200, data: [
+        Mock(fileExtensions: "png", contentType: .imagePNG, statusCode: 200, data: [
             .get: mockedData
         ]).register()
 
@@ -235,7 +235,7 @@ final class MockerTests: XCTestCase {
     /// It should be possible to test cancellation of requests with a delayed mock.
     func testDelayedMockCancelation() {
         let expectation = self.expectation(description: "Data request should be cancelled")
-        var mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+        var mock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()])
         mock.delay = DispatchTimeInterval.seconds(5)
         mock.register()
 
@@ -259,8 +259,8 @@ final class MockerTests: XCTestCase {
         #endif
         let expectation = self.expectation(description: "Data request should be cancelled")
         let urlWhichRedirects: URL = URL(string: "https://we.tl/redirect")!
-        Mock(url: urlWhichRedirects, dataType: .html, statusCode: 200, data: [.get: MockedData.redirectGET.data]).register()
-        Mock(url: URL(string: "https://wetransfer.com/redirect")!, dataType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data]).register()
+        Mock(url: urlWhichRedirects, contentType: .html, statusCode: 200, data: [.get: MockedData.redirectGET.data]).register()
+        Mock(url: URL(string: "https://wetransfer.com/redirect")!, contentType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data]).register()
 
         URLSession.shared.dataTask(with: urlWhichRedirects) { (data, _, _) in
 
@@ -310,7 +310,7 @@ final class MockerTests: XCTestCase {
     func testComposedURLMatch() {
         let composedURL = URL(fileURLWithPath: "resource", relativeTo: URL(string: "https://host.com/api/"))
         let simpleURL = URL(string: "https://host.com/api/resource")
-        let mock = Mock(url: composedURL, dataType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data])
+        let mock = Mock(url: composedURL, contentType: .json, statusCode: 200, data: [.get: MockedData.exampleJSON.data])
         let urlRequest = URLRequest(url: simpleURL!)
         XCTAssertEqual(composedURL.absoluteString, simpleURL?.absoluteString)
         XCTAssert(mock == urlRequest)
@@ -320,7 +320,7 @@ final class MockerTests: XCTestCase {
     func testMockCallbacks() {
         let onRequestExpectation = expectation(description: "Data request should start")
         let completionExpectation = expectation(description: "Data request should succeed")
-        var mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+        var mock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()])
         mock.onRequest = { _, _ in
             onRequestExpectation.fulfill()
         }
@@ -343,7 +343,7 @@ final class MockerTests: XCTestCase {
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
-        var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequest = { request, postBodyArguments in
             XCTAssertEqual(request.url, mock.request.url)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [String: String])
@@ -368,7 +368,7 @@ final class MockerTests: XCTestCase {
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONEncoder().encode(expectedParameters)
 
-        var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = .init(httpBodyType: RequestParameters.self, callback: { request, postBodyDecodable in
             XCTAssertEqual(request.url, mock.request.url)
             XCTAssertEqual(expectedParameters, postBodyDecodable)
@@ -389,7 +389,7 @@ final class MockerTests: XCTestCase {
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
-        var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = .init(jsonDictionaryCallback: { request, postBodyArguments in
             XCTAssertEqual(request.url, mock.request.url)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [String: String])
@@ -408,7 +408,7 @@ final class MockerTests: XCTestCase {
         var request = URLRequest(url: URL(string: "https://www.fakeurl.com")!)
         request.httpMethod = Mock.HTTPMethod.post.rawValue
 
-        var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = .init(callback: {
             onRequestExpectation.fulfill()
         })
@@ -428,7 +428,7 @@ final class MockerTests: XCTestCase {
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
-        var mock = Mock(url: request.url!, dataType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = OnRequestHandler(jsonArrayCallback: { request, postBodyArguments in
             XCTAssertEqual(request.url, mock.request.url)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [[String: String]])
@@ -445,13 +445,13 @@ final class MockerTests: XCTestCase {
     func testDelayedMock() {
         let nonDelayExpectation = expectation(description: "Data request should succeed")
         let delayedExpectation = expectation(description: "Data request should succeed")
-        var delayedMock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+        var delayedMock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()])
         delayedMock.delay = DispatchTimeInterval.seconds(1)
         delayedMock.completion = {
             delayedExpectation.fulfill()
         }
         delayedMock.register()
-        var nonDelayMock = Mock(dataType: .json, statusCode: 200, data: [.post: Data()])
+        var nonDelayMock = Mock(contentType: .json, statusCode: 200, data: [.post: Data()])
         nonDelayMock.completion = {
             nonDelayExpectation.fulfill()
         }
@@ -467,7 +467,7 @@ final class MockerTests: XCTestCase {
 
     /// It should remove all registered mocks correctly.
     func testRemoveAll() {
-        let mock = Mock(dataType: .json, statusCode: 200, data: [.get: Data()])
+        let mock = Mock(contentType: .json, statusCode: 200, data: [.get: Data()])
         mock.register()
         Mocker.removeAll()
         XCTAssertTrue(Mocker.shared.mocks.isEmpty)
@@ -476,8 +476,8 @@ final class MockerTests: XCTestCase {
     /// It should correctly add two mocks for the same URL if the HTTP method is different.
     func testDifferentHTTPMethodSameURL() {
         let url = URL(string: "https://www.fakeurl.com/\(UUID().uuidString)")!
-        Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()]).register()
-        Mock(url: url, dataType: .json, statusCode: 200, data: [.put: Data()]).register()
+        Mock(url: url, contentType: .json, statusCode: 200, data: [.get: Data()]).register()
+        Mock(url: url, contentType: .json, statusCode: 200, data: [.put: Data()]).register()
         var request = URLRequest(url: url)
         request.httpMethod = Mock.HTTPMethod.get.rawValue
         XCTAssertNotNil(Mocker.mock(for: request))
@@ -489,7 +489,7 @@ final class MockerTests: XCTestCase {
     func testOnRequestExpectation() {
         let url = URL(string: "https://www.fakeurl.com")!
 
-        var mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
+        var mock = Mock(url: url, contentType: .json, statusCode: 200, data: [.get: Data()])
         let expectation = expectationForRequestingMock(&mock)
         mock.register()
 
@@ -502,7 +502,7 @@ final class MockerTests: XCTestCase {
     func testOnCompletionExpectation() {
         let url = URL(string: "https://www.fakeurl.com")!
 
-        var mock = Mock(url: url, dataType: .json, statusCode: 200, data: [.get: Data()])
+        var mock = Mock(url: url, contentType: .json, statusCode: 200, data: [.get: Data()])
         let expectation = expectationForCompletingMock(&mock)
         mock.register()
 
@@ -522,7 +522,7 @@ final class MockerTests: XCTestCase {
             var errorDescription: String { "example" }
         }
 
-        Mock(url: originalURL, dataType: .json, statusCode: 500, data: [.get: Data()], requestError: TestExampleError.example).register()
+        Mock(url: originalURL, contentType: .json, statusCode: 500, data: [.get: Data()], requestError: TestExampleError.example).register()
 
         URLSession.shared.dataTask(with: originalURL) { (data, urlresponse, error) in
 
@@ -555,7 +555,7 @@ final class MockerTests: XCTestCase {
         let originalURL = URL(string: "https://www.wetransfer.com/example.json")!
 
         Mock(url: originalURL, cacheStoragePolicy: .allowed,
-             dataType: .json, statusCode: 200,
+             contentType: .json, statusCode: 200,
              data: [.get: MockedData.exampleJSON.data],
              additionalHeaders: ["Cache-Control": "public, max-age=31557600, immutable"]
         ).register()
@@ -589,7 +589,7 @@ final class MockerTests: XCTestCase {
         let unknownURL = URL(string: "www.netflix.com")!
 
         // Mocking
-        Mock(url: mockedURL, dataType: .json, statusCode: 200, data: [.get: Data()])
+        Mock(url: mockedURL, contentType: .json, statusCode: 200, data: [.get: Data()])
             .register()
 
         // Ignoring
@@ -613,7 +613,7 @@ final class MockerTests: XCTestCase {
         let unknownURL = URL(string: "www.netflix.com")!
 
         // Mocking
-        Mock(url: mockedURL, dataType: .json, statusCode: 200, data: [.get: Data()])
+        Mock(url: mockedURL, contentType: .json, statusCode: 200, data: [.get: Data()])
             .register()
 
         // Ignoring

--- a/Tests/MockerTests/MockerTests.swift
+++ b/Tests/MockerTests/MockerTests.swift
@@ -157,9 +157,7 @@ final class MockerTests: XCTestCase {
         var request = URLRequest(url: originalURL)
         request.httpMethod = "PUT"
 
-        Mock(url: originalURL, dataType: nil, statusCode: 202, data: [
-            .put: Data()
-        ]).register()
+        Mock(request: request, statusCode: 202).register()
 
         URLSession.shared.dataTask(with: request) { (data, response, _) in
             guard let response = response as? HTTPURLResponse else {

--- a/Tests/MockerTests/MockerTests.swift
+++ b/Tests/MockerTests/MockerTests.swift
@@ -151,7 +151,7 @@ final class MockerTests: XCTestCase {
     }
     
     /// No Content-Type should be included in the headers
-    func testNoDataType() {
+    func testNoContentType() {
         let expectation = self.expectation(description: "Data request should succeed")
         let originalURL = URL(string: "https://www.wetransfer.com/api/foobar")!
         var request = URLRequest(url: originalURL)


### PR DESCRIPTION
As discussed in https://github.com/WeTransfer/Mocker/issues/134

I've also added an additional initializer to simplify the mock creation in case a single non-get request has to be mocked.