### PR TITLE
Sort HTTP methods to remove randomness from keys

### DIFF
--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -320,8 +320,8 @@ public struct Mock: Equatable {
     }
 
     public static func == (lhs: Mock, rhs: Mock) -> Bool {
-        let lhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }
-        let rhsHTTPMethods: [String] = rhs.data.keys.compactMap { $0.rawValue }
+        let lhsHTTPMethods: [String] = lhs.data.keys.compactMap { $0.rawValue }.sorted()
+        let rhsHTTPMethods: [String] = rhs.data.keys.compactMap { $0.rawValue }.sorted()
 
         if let lhsFileExtensions = lhs.fileExtensions, let rhsFileExtensions = rhs.fileExtensions, (!lhsFileExtensions.isEmpty || !rhsFileExtensions.isEmpty) {
             /// The mocks are targeting file extensions specifically, check on those.

--- a/Tests/MockerTests/MockTests.swift
+++ b/Tests/MockerTests/MockTests.swift
@@ -32,4 +32,13 @@ final class MockTests: XCTestCase {
         XCTAssertEqual(mock200, mock400)
         XCTAssertNotEqual(mock200, mockJPEG)
     }
+    
+    func testMethodsComparing() {
+        let url = URL(string: "https://mocked.wetransfer.com")!
+        
+        let methods = [Mock.HTTPMethod.options, .get, .head, .post, .put, .patch, .delete, .trace, .connect]
+        let first = Mock(url: url, statusCode: 200, data: Dictionary(uniqueKeysWithValues: methods.shuffled().map { ($0, Data()) }))
+        let second = Mock(url: url, statusCode: 200, data: Dictionary(uniqueKeysWithValues: methods.shuffled().map { ($0, Data()) }))
+        XCTAssertEqual(first, second)
+    }
 }


### PR DESCRIPTION
Hello !

As `data.keys` returns in a random order, comparing 2 arrays containing same objects in different order make it return false. This way, it will return true as they will be sorted.