### PR TITLE
Simplify tests and add Sendable to subtypes

### DIFF
--- a/Sources/Mocker/Mock+DataType.swift
+++ b/Sources/Mocker/Mock+DataType.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Mock {
     /// The types of content of a request. Will be used as Content-Type header inside a `Mock`.
-    public struct DataType {
+    public struct DataType: Sendable {
 
         /// Name of the data type.
         public let name: String

--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -20,7 +20,7 @@ public struct Mock: Equatable {
     /// HTTP method definitions.
     ///
     /// See https://tools.ietf.org/html/rfc7231#section-4.3
-    public enum HTTPMethod: String {
+    public enum HTTPMethod: String, Sendable {
         case options = "OPTIONS"
         case get     = "GET"
         case head    = "HEAD"

--- a/Tests/MockerTests/MockerTests.swift
+++ b/Tests/MockerTests/MockerTests.swift
@@ -339,13 +339,14 @@ final class MockerTests: XCTestCase {
         let onRequestExpectation = expectation(description: "Data request should start")
 
         let expectedParameters = ["test": "value"]
-        var request = URLRequest(url: URL(string: "https://www.fakeurl.com")!)
+        let requestURL = URL(string: "https://www.fakeurl.com")!
+        var request = URLRequest(url: requestURL)
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
-        var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
+        var mock = Mock(url: requestURL, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequest = { request, postBodyArguments in
-            XCTAssertEqual(request.url, mock.request.url)
+            XCTAssertEqual(request.url, requestURL)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [String: String])
             onRequestExpectation.fulfill()
         }
@@ -364,13 +365,14 @@ final class MockerTests: XCTestCase {
         let onRequestExpectation = expectation(description: "Data request should start")
 
         let expectedParameters = RequestParameters(name: UUID().uuidString)
-        var request = URLRequest(url: URL(string: "https://www.fakeurl.com")!)
+        let requestURL = URL(string: "https://www.fakeurl.com")!
+        var request = URLRequest(url: requestURL)
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONEncoder().encode(expectedParameters)
 
         var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = .init(httpBodyType: RequestParameters.self, callback: { request, postBodyDecodable in
-            XCTAssertEqual(request.url, mock.request.url)
+            XCTAssertEqual(request.url, requestURL)
             XCTAssertEqual(expectedParameters, postBodyDecodable)
             onRequestExpectation.fulfill()
         })
@@ -385,13 +387,14 @@ final class MockerTests: XCTestCase {
         let onRequestExpectation = expectation(description: "Data request should start")
 
         let expectedParameters = ["test": "value"]
-        var request = URLRequest(url: URL(string: "https://www.fakeurl.com")!)
+        let requestURL = URL(string: "https://www.fakeurl.com")!
+        var request = URLRequest(url: requestURL)
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
         var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = .init(jsonDictionaryCallback: { request, postBodyArguments in
-            XCTAssertEqual(request.url, mock.request.url)
+            XCTAssertEqual(request.url, requestURL)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [String: String])
             onRequestExpectation.fulfill()
         })
@@ -424,13 +427,14 @@ final class MockerTests: XCTestCase {
         let onRequestExpectation = expectation(description: "Data request should start")
 
         let expectedParameters = [["test": "value"], ["test": "value"]]
-        var request = URLRequest(url: URL(string: "https://www.fakeurl.com")!)
+        let requestURL = URL(string: "https://www.fakeurl.com")!
+        var request = URLRequest(url: requestURL)
         request.httpMethod = Mock.HTTPMethod.post.rawValue
         request.httpBody = try JSONSerialization.data(withJSONObject: expectedParameters, options: .prettyPrinted)
 
         var mock = Mock(url: request.url!, contentType: .json, statusCode: 200, data: [.post: Data()])
         mock.onRequestHandler = OnRequestHandler(jsonArrayCallback: { request, postBodyArguments in
-            XCTAssertEqual(request.url, mock.request.url)
+            XCTAssertEqual(request.url, requestURL)
             XCTAssertEqual(expectedParameters, postBodyArguments as? [[String: String]])
             onRequestExpectation.fulfill()
         })


### PR DESCRIPTION
In an attempt to make Mocker conform to `Sendable`, I realized it's not making much sense for the nature of this project. Any mutations to `Mock` are done before the mock is registered and right now, it does not make any sense to change properties after registration.

If we would make `Mock` conform to `Sendable`, we would have to make all its properties including closures `Sendable` too. This would cause a huge impact on codebases since our tests are using `onRequest` handlers and others while capturing many non-sendable types. Therefore, I don't think it makes sense for this project, for testing purposes designed, to conform to Sendable in the short term.

Yet, I did add a few conformances that don't hurt 👌 