### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ $ brew install carthage
 To integrate Mocker into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "WeTransfer/Mocker" ~> 2.3.0
+github "WeTransfer/Mocker" ~> 3.0.0
 ```
 
 Run `carthage update` to build the framework and drag the built `Mocker.framework` into your Xcode project.
@@ -337,7 +337,7 @@ let package = Package(
        .macOS(.v10_15)
     ],
     dependencies: [
-        .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.3.0"))
+        .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
* Update to use the latest major version of the library in the installation parts of the README.  I had accidentally installed `2.6.0` when `3.0.0` was released 15 months ago.