### PR TITLE
feat: allow to pass a custom `JSONDecoder` to `OnRequestHandler`

### DIFF
--- a/Sources/Mocker/OnRequestHandler.swift
+++ b/Sources/Mocker/OnRequestHandler.swift
@@ -24,10 +24,19 @@ public struct OnRequestHandler {
     ///   - httpBodyType: The decodable type to use for parsing the request body.
     ///   - callback: The callback which will be called just before the request executes.
     public init<HTTPBody: Decodable>(httpBodyType: HTTPBody.Type?, callback: @escaping OnRequest<HTTPBody>) {
+        self.init(httpBodyType: httpBodyType, jsonDecoder: JSONDecoder(), callback: callback)
+    }
+
+    /// Creates a new request handler using the given `HTTPBody` type, which can be any `Decodable` and decoding it using the provided `JSONDecoder`.
+    /// - Parameters:
+    ///   - httpBodyType: The decodable type to use for parsing the request body.
+    ///   - jsonDecoder: The decoder to use for decoding the request body.
+    ///   - callback: The callback which will be called just before the request executes.
+    public init<HTTPBody: Decodable>(httpBodyType: HTTPBody.Type?, jsonDecoder: JSONDecoder, callback: @escaping OnRequest<HTTPBody>) {
         self.internalCallback = { request in
             guard
                 let httpBody = request.httpBodyStreamData() ?? request.httpBody,
-                let decodedObject = try? JSONDecoder().decode(HTTPBody.self, from: httpBody)
+                let decodedObject = try? jsonDecoder.decode(HTTPBody.self, from: httpBody)
             else {
                 callback(request, nil)
                 return


### PR DESCRIPTION
This PR allows providing a custom instance of `JSONEncoder` while initializing the `OnRequestHandler`. 

#### Motivation
Some API endpoints require all JSON keys in payloads to adhere to the _snake-case_ naming convention. However, to be consistent with the Swift naming convention, we use _camelCase_  naming convention for declaring properties in underlying Codable structures (JSON models). When calling the API, we configure the Alamofire key encoding strategy to _snake-case_ (`encoder.keyEncodingStrategy = .convertToSnakeCase`). Unfortunately, with the current implementation, it is not possible to mock such endpoints, as the request handler always uses the default `JSONDecoder()` for parsing/decoding the request body.

After applying this PR, it will be possible to configure the `JSONDecoder` as needed; for example, in our case, to set the key decoding strategy to _snake_case_:

```
let decoder = JSONDecoder()
decoder.keyDecodingStrategy = .convertFromSnakeCase

mock.onRequestHandler = OnRequestHandler(httpBodyType: BodyType.self, jsonDecoder: decoder) { _, body in
	// Assertions
}
```