### PR TITLE
Option to ignore URLs that match a prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,18 @@ Mock(url: URL(string: "https://wetransfer.com/redirect")!, contentType: .json, s
 As the Mocker catches all URLs by default when registered, you might end up with a `fatalError` thrown in cases you don't need a mocked request. In that case, you can ignore the URL:
 
 ```swift
-let ignoredURL = URL(string: "www.wetransfer.com")!
+let ignoredURL = URL(string: "https://www.wetransfer.com")!
+
+// Ignore any requests that exactly match the URL
 Mocker.ignore(ignoredURL)
+
+// Ignore any requests that match the URL, with any query parameters
+// e.g. https://www.wetransfer.com?foo=bar would be ignored
+Mocker.ignore(ignoredURL, matchType: .ignoreQuery)
+
+// Ignore any requests that begin with the URL
+// e.g. https://www.wetransfer.com/api/v1 would be ignored
+Mocker.ignore(ignoredURL, matchType: .prefix)
 ```
 
 However, if you need the Mocker to catch only mocked URLs and ignore every other URL, you can set the `mode` attribute to `.optin`. 

--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -331,11 +331,3 @@ public struct Mock: Equatable {
         return lhs.request.url!.absoluteString == rhs.request.url!.absoluteString && lhsHTTPMethods == rhsHTTPMethods
     }
 }
-
-extension URL {
-    /// Returns the base URL string build with the scheme, host and path. "https://www.wetransfer.com/v1/test?param=test" would be "https://www.wetransfer.com/v1/test".
-    var baseString: String? {
-        guard let scheme = scheme, let host = host else { return nil }
-        return scheme + "://" + host + path
-    }
-}

--- a/Sources/Mocker/URLMatchType.swift
+++ b/Sources/Mocker/URLMatchType.swift
@@ -1,0 +1,44 @@
+//
+//  URLMatchType.swift
+//  Mocker
+//
+//  Created by Brent Whitman on 2024-04-18.
+//
+
+import Foundation
+
+/// How to check if one URL matches another.
+public enum URLMatchType {
+    /// Matches the full URL, including the query
+    case full
+    /// Matches the URL excluding the query
+    case ignoreQuery
+    /// Matches if the URL begins with the prefix
+    case prefix
+}
+
+extension URL {
+    /// Returns the base URL string build with the scheme, host and path. "https://www.wetransfer.com/v1/test?param=test" would be "https://www.wetransfer.com/v1/test".
+    var baseString: String? {
+        guard let scheme = scheme, let host = host else { return nil }
+        return scheme + "://" + host + path
+    }
+    
+    /// Checks if  this URL matches the passed URL using the provided match type.
+    ///
+    /// - Parameter url: The URL to check for a match.
+    /// - Parameter matchType: The approach that will be used to determine whether this URL match the provided URL. Defaults to `full`.
+    /// - Returns: `true` if the URL matches based on the match type; `false` otherwise.
+    func matches(_ otherURL: URL?, matchType: URLMatchType = .full) -> Bool {
+        guard let otherURL else { return false }
+        
+        switch matchType {
+        case .full:
+            return absoluteString == otherURL.absoluteString
+        case .ignoreQuery:
+            return baseString == otherURL.baseString
+        case .prefix:
+            return absoluteString.hasPrefix(otherURL.absoluteString)
+        }
+    }
+}

--- a/Tests/MockerTests/MockerTests.swift
+++ b/Tests/MockerTests/MockerTests.swift
@@ -302,8 +302,20 @@ final class MockerTests: XCTestCase {
         let ignoredURLQueries = URL(string: "https://www.wetransfer.com/sample-image.png?width=200&height=200")!
 
         XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)))
-        Mocker.ignore(ignoredURL, ignoreQuery: true)
+        Mocker.ignore(ignoredURL, matchType: .ignoreQuery)
         XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLQueries)))
+    }
+
+    /// It should be possible to ignore URL prefixes and not let them be handled.
+    func testIgnoreURLsIgnorePrefixes() {
+
+        let ignoredURL = URL(string: "https://www.wetransfer.com/private")!
+        let ignoredURLSubPath = URL(string: "https://www.wetransfer.com/private/sample-image.png")!
+
+        XCTAssertTrue(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLSubPath)))
+        Mocker.ignore(ignoredURL, matchType: .prefix)
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURLSubPath)))
+        XCTAssertFalse(MockingURLProtocol.canInit(with: URLRequest(url: ignoredURL)))
     }
 
     /// It should be possible to compose a url relative to a base and still have it match the full url


### PR DESCRIPTION
Resolves #93.

Extend the Mocker's ignore rules to have an option to ignore any URLs that start with a specific prefix. This expands on existing functionality that has ignore rules for ignoring URLs that match exactly, or matching the URL excluding the query.

If this PR is approved, it may be nice to consider a follow-up PR to make a similar change to the `Mock` struct, migrating its use of `ignoreQuery` to also use a `URLMatchType` approach. If this is of interest to the repo maintainers, I could open an issue for further discussion, for example on how to deal the proliferation of public initializers as mentioned here https://github.com/WeTransfer/Mocker/pull/140#issuecomment-1315937869