### PR TITLE
Response handler for dynamic requests (POC) 

### DIFF
--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -101,6 +101,9 @@ public struct Mock: Equatable {
     /// The on request handler which will be executed everytime this `Mock` was started. Can be used within unit tests for validating that a request has been started. The handler must be set before calling `register`.
     public var onRequestHandler: OnRequestHandler?
 
+    /// Optional response handler which could be used to dynamically generate the response
+    public var responseHandler: ResponseHandler?
+
     /// Can only be set internally as it's used by the `expectationForRequestingMock(_:)` method.
     var onRequestExpectation: XCTestExpectation?
 
@@ -288,6 +291,30 @@ public struct Mock: Equatable {
             additionalHeaders: additionalHeaders,
             fileExtensions: nil
         )
+    }
+
+    /// Creates a `Mock` for the given `URLRequest`.
+    ///
+    /// - Parameters:
+    ///   - request: The URLRequest, from which the URL and request method is used to match for and to return the mocked data for.
+    ///   - ignoreQuery: If `true`, checking the URL will ignore the query and match only for the scheme, host and path. Defaults to `false`.
+    ///   - cacheStoragePolicy: The caching strategy. Defaults to `notAllowed`.
+    ///   - responseHandler: The response handler to dynamicly generate the response for this Mock
+    public init(request: URLRequest, ignoreQuery: Bool = false, cacheStoragePolicy: URLCache.StoragePolicy = .notAllowed, responseHandler: ResponseHandler) {
+        guard let requestHTTPMethod = Mock.HTTPMethod(rawValue: request.httpMethod ?? "") else {
+            preconditionFailure("Unexpected http method")
+        }
+
+        self.init(
+            url: request.url,
+            ignoreQuery: ignoreQuery,
+            cacheStoragePolicy: cacheStoragePolicy,
+            statusCode: 999, // unused, see responseHandler
+            data: [requestHTTPMethod: "responseHandler should have been used instead of this".data(using: .utf8)!],
+            fileExtensions: nil
+        )
+
+        self.responseHandler = responseHandler
     }
 
     /// Registers the mock with the shared `Mocker`.

--- a/Sources/Mocker/Mock.swift
+++ b/Sources/Mocker/Mock.swift
@@ -339,11 +339,17 @@ public struct Mock: Equatable {
             // If the mock contains a file extension, this should always be used to match for.
             guard let pathExtension = request.url?.pathExtension else { return false }
             return fileExtensions.contains(pathExtension)
-        } else if mock.ignoreQuery {
-            return mock.request.url!.baseString == request.url?.baseString && mock.data.keys.contains(requestHTTPMethod)
         }
 
-        return mock.request.url!.absoluteString == request.url?.absoluteString && mock.data.keys.contains(requestHTTPMethod)
+        if mock.ignoreQuery {
+            if mock.request.url!.baseString != request.url?.baseString {
+                return false
+            }
+        } else if mock.request.url!.absoluteString != request.url?.absoluteString {
+            return false
+        }
+
+        return mock.responseHandler != nil || mock.data.keys.contains(requestHTTPMethod)
     }
 
     public static func == (lhs: Mock, rhs: Mock) -> Bool {

--- a/Sources/Mocker/ResponseHandler.swift
+++ b/Sources/Mocker/ResponseHandler.swift
@@ -1,23 +1,21 @@
 //
-//  OnRequestHandler.swift
-//  
+//  RequestResponseHandler.swift
 //
-//  Created by Antoine van der Lee on 03/11/2022.
+//
+//  Created by Tieme on 03/10/2024.
 //  Copyright © 2022 WeTransfer. All rights reserved.
-//
 
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
-/// A handler for verifying outgoing requests.
-public struct OnRequestHandler {
+/// A handler for a dynamic response
+public struct ResponseHandler {
 
-    public typealias OnRequest<HTTPBody> = (_ request: URLRequest, _ httpBody: HTTPBody?) -> Void
+    public typealias OnRequest<HTTPBody> = (_ request: URLRequest, _ httpBody: HTTPBody?) -> (HTTPURLResponse, Data)
 
-    private let internalCallback: (_ request: URLRequest) -> Void
-    let legacyCallback: Mock.OnRequest?
+    private let internalCallback: (_ request: URLRequest) -> (HTTPURLResponse, Data)
 
     /// Creates a new request handler using the given `HTTPBody` type, which can be any `Decodable`.
     /// - Parameters:
@@ -38,102 +36,55 @@ public struct OnRequestHandler {
                 let httpBody = request.httpBodyStreamData() ?? request.httpBody,
                 let decodedObject = try? jsonDecoder.decode(HTTPBody.self, from: httpBody)
             else {
-                callback(request, nil)
-                return
+                return callback(request, nil)
             }
-            callback(request, decodedObject)
+            return callback(request, decodedObject)
         }
-        legacyCallback = nil
     }
 
     /// Creates a new request handler using the given callback to call on request without parsing the body arguments.
     /// - Parameter requestCallback: The callback which will be executed just before the request executes, containing the request.
-    public init(requestCallback: @escaping (_ request: URLRequest) -> Void) {
+    public init(requestCallback: @escaping (_ request: URLRequest) -> (HTTPURLResponse, Data)) {
         self.internalCallback = requestCallback
-        legacyCallback = nil
     }
 
     /// Creates a new request handler using the given callback to call on request without parsing the body arguments and without passing the request.
     /// - Parameter callback: The callback which will be executed just before the request executes.
-    public init(callback: @escaping () -> Void) {
+    public init(callback: @escaping () -> (HTTPURLResponse, Data)) {
         self.internalCallback = { _ in
             callback()
         }
-        legacyCallback = nil
     }
 
     /// Creates a new request handler using the given callback to call on request.
     /// - Parameter jsonDictionaryCallback: The callback that executes just before the request executes, containing the HTTP Body Arguments as a JSON Object Dictionary.
-    public init(jsonDictionaryCallback: @escaping ((_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> Void)) {
+    public init(jsonDictionaryCallback: @escaping ((_ request: URLRequest, _ httpBodyArguments: [String: Any]?) -> (HTTPURLResponse, Data))) {
         self.internalCallback = { request in
             guard
                 let httpBody = request.httpBodyStreamData() ?? request.httpBody,
                 let jsonObject = try? JSONSerialization.jsonObject(with: httpBody, options: .fragmentsAllowed) as? [String: Any]
             else {
-                jsonDictionaryCallback(request, nil)
-                return
+                return jsonDictionaryCallback(request, nil)
             }
-            jsonDictionaryCallback(request, jsonObject)
+            return jsonDictionaryCallback(request, jsonObject)
         }
-        self.legacyCallback = nil
     }
 
     /// Creates a new request handler using the given callback to call on request.
     /// - Parameter jsonDictionaryCallback: The callback that executes just before the request executes, containing the HTTP Body Arguments as a JSON Object Array.
-    public init(jsonArrayCallback: @escaping ((_ request: URLRequest, _ httpBodyArguments: [[String: Any]]?) -> Void)) {
+    public init(jsonArrayCallback: @escaping ((_ request: URLRequest, _ httpBodyArguments: [[String: Any]]?) -> (HTTPURLResponse, Data))) {
         self.internalCallback = { request in
             guard
                 let httpBody = request.httpBodyStreamData() ?? request.httpBody,
                 let jsonObject = try? JSONSerialization.jsonObject(with: httpBody, options: .fragmentsAllowed) as? [[String: Any]]
             else {
-                jsonArrayCallback(request, nil)
-                return
+                return jsonArrayCallback(request, nil)
             }
-            jsonArrayCallback(request, jsonObject)
+            return jsonArrayCallback(request, jsonObject)
         }
-        self.legacyCallback = nil
     }
 
-    init(legacyCallback: Mock.OnRequest?) {
-        self.internalCallback = { request in
-            guard
-                let httpBody = request.httpBodyStreamData() ?? request.httpBody,
-                let jsonObject = try? JSONSerialization.jsonObject(with: httpBody, options: .fragmentsAllowed) as? [String: Any]
-            else {
-                legacyCallback?(request, nil)
-                return
-            }
-            legacyCallback?(request, jsonObject)
-        }
-        self.legacyCallback = legacyCallback
-    }
-
-    func handleRequest(_ request: URLRequest) {
-        internalCallback(request)
+    func handleRequest(_ request: URLRequest) -> (HTTPURLResponse, Data) {
+        return internalCallback(request)
     }
 }
-
-extension URLRequest {
-    /// We need to use the http body stream data as the URLRequest once launched converts the `httpBody` to this stream of data.
-    func httpBodyStreamData() -> Data? {
-        guard let bodyStream = self.httpBodyStream else { return nil }
-
-        bodyStream.open()
-
-        // Will read 16 chars per iteration. Can use bigger buffer if needed
-        let bufferSize: Int = 16
-        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-        var data = Data()
-
-        while bodyStream.hasBytesAvailable {
-            let readData = bodyStream.read(buffer, maxLength: bufferSize)
-            data.append(buffer, count: readData)
-        }
-
-        buffer.deallocate()
-        bodyStream.close()
-
-        return data
-    }
-}
-


### PR DESCRIPTION
I'm using Mocker as mock backend for our app to be able to develop the app in "demo mode" as long as other developers are still working on the backend. 

This sometimes requires a more dynamic response to be returned from the mocks based on the request body or previous requests. I considered creating something from scratch based off Mocker, but instead I've added a simple `responseHandler` option to my own fork to facilitate this. 

It works great and just using my own fork works fine, but I can imagine that this could be valuable for other developers as well. Here's a POC branch that demonstrates this. If you think this is something that would benefit Mocker, I could draft up a real PR with a nicer implementation if you like. 