### PR TITLE
Fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,10 +352,10 @@ let package = Package(
     targets: [
         .target(
             name: "MyProject",
-            dependencies: ["Mocker"]),
+            dependencies: []),
         .testTarget(
             name: "MyProjectTests",
-            dependencies: ["MyProject"]),
+            dependencies: ["MyProject", "Mocker"]),
     ]
 )
 ```


### PR DESCRIPTION
Hello.
Thank you for Mocker.
Found out that Mocker should be used in test targets only because of `import XCTest`.